### PR TITLE
Read z-index parameter before creating Twilio's WebChat

### DIFF
--- a/src/aselo-webchat.ts
+++ b/src/aselo-webchat.ts
@@ -2,7 +2,7 @@ import * as FlexWebChat from '@twilio/flex-webchat-ui';
 import { Channel } from 'twilio-chat/lib/channel';
 import { getUserIp } from './ip-tracker';
 import { getCurrentConfig } from '../configurations';
-import { updateZIndex } from './dom-utils';
+import { updateZIndex, ScriptParameter } from './dom-utils';
 
 const currentConfig = getCurrentConfig();
 const defaultLanguage = currentConfig.defaultLanguage;
@@ -74,7 +74,7 @@ const setChannelAfterStartEngagement = doWithChannel((channel: Channel, manager:
   channel.sendMessage(translations[initialLanguage].AutoFirstMessage);
 })
 
-export const initWebchat = async () => {
+export const initWebchat = async (zIndex: ScriptParameter) => {
   let ip;
 
   if (currentConfig.captureIp) {
@@ -133,5 +133,5 @@ export const initWebchat = async () => {
 
   // Render WebChat
   webchat.init();
-  updateZIndex();
+  updateZIndex(zIndex);
 };

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -1,12 +1,13 @@
 const CONTAINER_ID = 'twilio-customer-frame';
 
+export type ScriptParameter = string | null | undefined;
+
 /**
  * Updates Webchat container z-index with the value provided by the client.
  * Sample: <script src="point/to/aselo-webchat.min.js" data-z-index="200">
  */
-export function updateZIndex() {
+export function updateZIndex(zIndex: ScriptParameter) {
   const container = document?.getElementById(CONTAINER_ID);
-  const zIndex = document?.currentScript?.getAttribute('data-z-index');
 
   if (container && zIndex) {
     container.style.zIndex = zIndex;

--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,7 @@
     <title>My chat</title>
 </head>
 <body>
-    <script src="./bundle.js"></script>
+    <div style="position:fixed; left:0; right:0; bottom:0; height:123px; background-color:#261E3C;z-index:999999;"></div>
+    <script data-z-index="16000160" src="./bundle.js"></script>
 </body>
 </html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 import { initWebchat } from './aselo-webchat';
 
-initWebchat();
+const zIndex = document?.currentScript?.getAttribute('data-z-index');
+initWebchat(zIndex);


### PR DESCRIPTION
In order to read the given **z-index** in `<script data-z-index="999" src="aselo-chat.js"></script>` we use this line of code `document.currentScript`. But, according to the [documentation](https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript) this can't be run as a callback or event handler (it always returns `null` in those scenarios).

To easily fix this, we can call `document.currentScript` right at the beginning of our code, before we start handling with async code.