### PR TITLE
Fix language and helpline dropdowns z-index

### DIFF
--- a/src/aselo-webchat.ts
+++ b/src/aselo-webchat.ts
@@ -2,7 +2,9 @@ import * as FlexWebChat from '@twilio/flex-webchat-ui';
 import { Channel } from 'twilio-chat/lib/channel';
 import { getUserIp } from './ip-tracker';
 import { getCurrentConfig } from '../configurations';
-import { updateZIndex, ScriptParameter } from './dom-utils';
+import { updateZIndex } from './dom-utils';
+
+updateZIndex();
 
 const currentConfig = getCurrentConfig();
 const defaultLanguage = currentConfig.defaultLanguage;
@@ -75,7 +77,7 @@ const setChannelAfterStartEngagement = doWithChannel((channel: Channel, manager:
   channel.sendMessage(message); 
 })
 
-export const initWebchat = async (zIndex: ScriptParameter) => {
+export const initWebchat = async () => {
   let ip: string | undefined;
 
   if (currentConfig.captureIp) {
@@ -134,5 +136,4 @@ export const initWebchat = async (zIndex: ScriptParameter) => {
 
   // Render WebChat
   webchat.init();
-  updateZIndex(zIndex);
 };

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -1,16 +1,39 @@
 const CONTAINER_ID = 'twilio-customer-frame';
+const HELPLINE_SELECT_ID = 'menu-helpline';
+const LANGUAGE_SELECT_ID = 'menu-language';
 
-export type ScriptParameter = string | null | undefined;
+// Array of ids from elements that need z-index update
+const nodeIds = [CONTAINER_ID, LANGUAGE_SELECT_ID, HELPLINE_SELECT_ID];
 
 /**
  * Updates Webchat container z-index with the value provided by the client.
  * Sample: <script src="point/to/aselo-webchat.min.js" data-z-index="200">
+ * 
+ * How it works?
+ * It uses MutationObserver to listen to DOM changes. Everytime it detects a new node was added
+ * to `document.body` (or children), it checks if this element needs to have its z-index set.
  */
-export function updateZIndex(zIndex: ScriptParameter) {
-  const container = document?.getElementById(CONTAINER_ID);
+export function updateZIndex() {
+  const zIndex = document?.currentScript?.getAttribute('data-z-index');
+  if (zIndex === null || zIndex === undefined) return;
 
-  if (container && zIndex) {
-    container.style.zIndex = zIndex;
-    container.style.position = 'relative';
-  }
+  let observer = new window.MutationObserver(mutations => {
+    mutations.forEach(mutation => {
+      mutation.addedNodes.forEach(node => {
+        if (isHTMLElement(node) && nodeIds.includes(node.id)) {
+          node.style.zIndex = zIndex;
+
+          if (CONTAINER_ID === node.id) {
+            node.style.position = 'relative';
+          }
+        }
+      });
+    })
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
+}
+
+function isHTMLElement(node: Node): node is HTMLElement {
+  return node.nodeType === Node.ELEMENT_NODE;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
 import { initWebchat } from './aselo-webchat';
 
-const zIndex = document?.currentScript?.getAttribute('data-z-index');
-initWebchat(zIndex);
+initWebchat();


### PR DESCRIPTION
Twilio's Webchat dropdowns are not the native HTML `select` components, but a custom implementation. In summary, when we open a dropdown it actually creates another `div` in the dom, that's not a child of the webchat widget. Because of that, the webchat's z-index has no effect on these dropdowns.

This PR changes the way z-indexes are applied. Now, we listen to the new elements added to the DOM, and we add a z-index to them if their id is one of the following:
- `twilio-customer-frame` (the widget's container)
- `menu-helpline` (the `div` generated for helpline dropdown)
- `menu-language` (the `div` generated for language dropdown)

In the current implementation, we have to pay attention when adding new dropdowns: we need to add their ids into`nodeIds`: an array of ids with the elements that need to have z-index applied (currently the dropdowns and the widgets container).

**Future implementation**
One risky improvement to the current code is to guess these ids automatically. When we create a new dropdown with name `custom`, the id generated for the dropdown `div` will be `menu-custom`. We could easily write some code to apply z-index to all `menu-xxx` elements, but there's a chance another element on the page (not related to the webchat) to have the exact same id, eg. `menu-category`. So for now, it's safer to just "whitelist" the ids. Later on, we could think of prefixing our pre-engagement field names with something like `aselo-chat-xxx`, so the auto generated ids would be `menu-aselo-chat-xxx`. In this case, it would be very unlikely for another random element on the screen to have the same id. But that change would require us to change Flex Studios flows for all helplines (update the pre-engagement data names).

