### PR TITLE
Remove goodbye message from message tray

### DIFF
--- a/configurations/beta.ts
+++ b/configurations/beta.ts
@@ -7,16 +7,16 @@ const captureIp = true;
 
 const translations: Translations = {
   'ar': {
-    MessageCanvasTrayContent: "<p dir='rtl'>المستشار غادر الدردشة. شكرا لك على التواصل. يرجى الاتصال بنا مرة أخرى إذا كنت بحاجة إلى مزيد من المساعدة.</p>",
+    MessageCanvasTrayContent: '',
     AutoFirstMessage: '',
   },
   'el': {
-    MessageCanvasTrayContent: "<p>Ο σύμβουλος εγκατέλειψε τη συνομιλία. Σας ευχαριστούμε που επικοινωνήσατε. Παρακαλώ επικοινωνήστε μαζί μας ξανά εάν χρειάζεστε περισσότερη βοήθεια.</p>",
+    MessageCanvasTrayContent: '',
     AutoFirstMessage: '',
   },
   'en-US': {
     WelcomeMessage: "Welcome to Aselo!",
-    MessageCanvasTrayContent: "<p>The counsellor has left the chat. Thank you for reaching out. Please contact us again if you need more help.</p>",
+    MessageCanvasTrayContent: '',
     MessageInputDisabledReasonHold: "Please hold for a counsellor.",
     AutoFirstMessage: "Incoming webchat contact from",
   },
@@ -44,23 +44,23 @@ const translations: Translations = {
 
     BotGreeting: "¿Cómo puedo ayudar?",
     WelcomeMessage: "¡Bienvenido a Aselo!",
-    MessageCanvasTrayContent: "<p>El consejero abandonó el chat. Gracias por contactarnos. Por favor contáctenos nuevamente si necesita más ayuda.</p>",
+    MessageCanvasTrayContent: '',
     AutoFirstMessage: '',
   },
   'da': {
-    MessageCanvasTrayContent: "<p>Rådgiveren har forladt chatten. Tak, fordi du nåede ud. Kontakt os igen, hvis du har brug for mere hjælp.</p>",
+    MessageCanvasTrayContent: '',
     AutoFirstMessage: '',
   },
   'it': {
-    MessageCanvasTrayContent: "<p>Il consulente ha lasciato la chat. Grazie per averci contattato. Vi preghiamo di contattarci nuovamente se avete bisogno di ulteriore aiuto.</p>",
+    MessageCanvasTrayContent: '',
     AutoFirstMessage: '',
   },
   'km': {
-    MessageCanvasTrayContent: "<p>អ្នកផ្តល់យោបល់បានចាកចេញពីការជជែក។ សូមអរគុណចំពោះការឈានទៅដល់។ សូមទាក់ទងមកយើងម្តងទៀតប្រសិនបើអ្នកត្រូវការជំនួយបន្ថែម។</p>",
+    MessageCanvasTrayContent: '',
     AutoFirstMessage: '',
   },
   'sv': {
-    MessageCanvasTrayContent: "<p>Rådgivaren har lämnat chatten. Tack för att du når ut. Kontakta oss igen om du behöver mer hjälp.</p>",
+    MessageCanvasTrayContent: '',
     AutoFirstMessage: '',
   }
 };

--- a/configurations/za-staging.ts
+++ b/configurations/za-staging.ts
@@ -8,7 +8,7 @@ const captureIp = true;
 const translations: Translations = {
   'en-US': {
     WelcomeMessage: "Welcome to Aselo!",
-    MessageCanvasTrayContent: "<p>The counselor has left the chat. Thank you for reaching out. Please contact us again if you need more help.</p>",
+    MessageCanvasTrayContent: "",
     MessageInputDisabledReasonHold: "Please hold for a counselor.",
     AutoFirstMessage: "Incoming webchat contact from",
   },


### PR DESCRIPTION
On Both ZA and Beta environments the child was receiving the goodbye message twice (in the chat area and in the tray area above the Start new chat button). This PR removes the goodbye message from the tray area.

See issue below:
![image](https://user-images.githubusercontent.com/1504544/121385449-08a4b000-c941-11eb-98b8-573fe97f9f0a.png)