### PR TITLE
Upgrade Flex Webchat to 2.9.1 and patch handlebars vuln

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,51 +5,50 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
       "requires": {
-        "@babel/highlight": "^7.12.13"
+        "@babel/highlight": "^7.14.5"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
-      "integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
+      "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
       "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.14.5"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+      "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg=="
     },
     "@babel/highlight": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
-      "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/helper-validator-identifier": "^7.14.5",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
     },
     "@babel/runtime": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.13.tgz",
-      "integrity": "sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==",
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+      "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/types": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.13.tgz",
-      "integrity": "sha512-oKrdZTld2im1z8bDwTOQvUbxKwE+854zc16qWZQlcTqMN00pWxHQ4ZeOq0yDMnisOpRykH2/5Qqcrk/OlbAjiQ==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+      "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.12.11",
-        "lodash": "^4.17.19",
+        "@babel/helper-validator-identifier": "^7.14.5",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -124,9 +123,9 @@
       "integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw=="
     },
     "@material-ui/core": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-3.9.3.tgz",
-      "integrity": "sha512-REIj62+zEvTgI/C//YL4fZxrCVIySygmpZglsu/Nl5jPqy3CDjZv1F9ubBYorHqmRgeVPh64EghMMWqk4egmfg==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-3.9.4.tgz",
+      "integrity": "sha512-r8QFLSexcYZbnqy/Hn4v8xzmAJV41yaodUVjmbGLi1iGDLG3+W941hEtEiBmxTRRqv2BdK3r4ijILcqKmDv/Sw==",
       "requires": {
         "@babel/runtime": "^7.2.0",
         "@material-ui/system": "^3.0.0-alpha.0",
@@ -231,46 +230,51 @@
       }
     },
     "@twilio/flex-sdk": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@twilio/flex-sdk/-/flex-sdk-0.4.3.tgz",
-      "integrity": "sha512-rOej+37ykxX1ghgbV37HpTIqlX8C4wlNzhKv3DV1eS8dEsiODbQ1IjQE0xONB+JVAgDE0A6KgKJN8HrswswmEg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-sdk/-/flex-sdk-0.6.0.tgz",
+      "integrity": "sha512-g7JTAug6g0oJk5xx1m5IRovkbkRHNcr3v40YTqKVNRljdw8/zJRxVjbm/SUBdtSP6KSYb2SEkJtN49Y6cDjopQ==",
       "requires": {
-        "core-js": "^3.6.4",
+        "core-js": "^3.9.1",
         "inversify": "^5.0.1",
-        "lodash.camelcase": "^4.3.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.mapkeys": "^4.6.0",
-        "lodash.mergewith": "^4.6.2",
-        "lodash.snakecase": "^4.1.1",
-        "lodash.transform": "^4.6.0",
-        "loglevel": "^1.6.7",
+        "lodash": "^4.17.21",
+        "loglevel": "^1.7.0",
+        "node-fetch": "^2.6.1",
         "reflect-metadata": "^0.1.13",
-        "twilio-sync": "^0.12.0",
-        "twilsock": "^0.5.12"
+        "twilio-sync": "^0.13.0",
+        "twilsock": "^0.8.3"
       },
       "dependencies": {
         "core-js": {
-          "version": "3.8.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
-          "integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q=="
+          "version": "3.15.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.2.tgz",
+          "integrity": "sha512-tKs41J7NJVuaya8DxIOCnl8QuPHx5/ZVbFo1oKgVl1qHFBBrDctzQGtuLjPpRdNTWmKPH6oEvgN/MUID+l485Q=="
+        },
+        "loglevel": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
+          "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw=="
+        },
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         }
       }
     },
     "@twilio/flex-ui-core": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@twilio/flex-ui-core/-/flex-ui-core-0.47.0.tgz",
-      "integrity": "sha512-Hz++enGE876T5rYdRuQA/WU8ze/mB/Zk2DoYJcSYcwmZfG2Bwq+LxYN/2mkoI/6RcoFRoODdvdjapVF6zEg/ow==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-ui-core/-/flex-ui-core-0.51.1.tgz",
+      "integrity": "sha512-wDe5KPYewdQD0JOgxVUE3znnDyZwZpEG/S32JyAayBHMVCiUN97ij4ACiFXjv4bbSnsUgzWt6xU4yG+uROlBgQ==",
       "requires": {
-        "@material-ui/core": "3.9.3",
+        "@material-ui/core": "3.9.4",
         "@material-ui/icons": "2.0.3",
-        "@twilio/flex-sdk": "0.4.3",
+        "@twilio/flex-sdk": "^0.6.0",
         "core-js": "^3.0.1",
         "create-emotion-styled": "^9.2.6",
         "emotion": "9.2.6",
         "emotion-theming": "9.2.6",
         "google-libphonenumber": "3.2.6",
-        "handlebars": "4.7.6",
-        "hex-rgb": "3.0.0",
+        "handlebars": "~4.7.7",
         "hoist-non-react-statics": "3.3.0",
         "lodash.debounce": "4.0.8",
         "loglevel": "1.6.7",
@@ -290,9 +294,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.8.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
-          "integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q=="
+          "version": "3.15.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.2.tgz",
+          "integrity": "sha512-tKs41J7NJVuaya8DxIOCnl8QuPHx5/ZVbFo1oKgVl1qHFBBrDctzQGtuLjPpRdNTWmKPH6oEvgN/MUID+l485Q=="
         },
         "hoist-non-react-statics": {
           "version": "3.3.0",
@@ -305,12 +309,12 @@
       }
     },
     "@twilio/flex-webchat-ui": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@twilio/flex-webchat-ui/-/flex-webchat-ui-2.7.1.tgz",
-      "integrity": "sha512-vtu2ZR1f/jg9hYlDnIEJr5gGGryEL5KlMWl7BmriTmu4wdMm5z4+7KD4zc/NYY0x4skpGWpOjPGw92dMhR6buQ==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-webchat-ui/-/flex-webchat-ui-2.9.1.tgz",
+      "integrity": "sha512-4vjP2FBfAT42JvLhxmgEoHtOM49+apwDGU8qNb5srwoFj3PWnyXSJFuOZx4I0a7InlPPzyxlCk2uO/3si65r7Q==",
       "requires": {
-        "@material-ui/core": "3.9.3",
-        "@twilio/flex-ui-core": "0.47.0",
+        "@material-ui/core": "3.9.4",
+        "@twilio/flex-ui-core": "0.51.1",
         "axios": "^0.21.1",
         "core-js": "^2.6.5",
         "create-emotion-styled": "^9.2.6",
@@ -405,23 +409,24 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "@types/prop-types": {
-      "version": "15.7.3",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
+      "version": "15.7.4",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
     },
     "@types/react": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.1.tgz",
-      "integrity": "sha512-w8t9f53B2ei4jeOqf/gxtc2Sswnc3LBK5s0DyJcg5xd10tMHXts2N31cKjWfH9IC/JvEPa/YF1U4YeP1t4R6HQ==",
+      "version": "17.0.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.14.tgz",
+      "integrity": "sha512-0WwKHUbWuQWOce61UexYuWTGuGY/8JvtUe/dtQ6lR4sZ3UiylHotJeWpf3ArP9+DSGUoLY3wbU59VyMrJps5VQ==",
       "requires": {
         "@types/prop-types": "*",
+        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
-          "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+          "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
         }
       }
     },
@@ -432,6 +437,11 @@
       "requires": {
         "@types/react": "*"
       }
+    },
+    "@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@webassemblyjs/ast": {
       "version": "1.11.0",
@@ -1376,9 +1386,9 @@
       }
     },
     "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
     "clean-css": {
       "version": "4.2.3",
@@ -1540,9 +1550,9 @@
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
       "requires": {
         "safe-buffer": "~5.1.1"
       }
@@ -1648,14 +1658,14 @@
       "dev": true
     },
     "csstype": {
-      "version": "2.6.14",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
-      "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
+      "version": "2.6.17",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
+      "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A=="
     },
     "debounce": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.0.tgz",
-      "integrity": "sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
     },
     "debug": {
       "version": "4.3.1",
@@ -2659,9 +2669,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "requires": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
@@ -2753,11 +2763,6 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
-    },
-    "hex-rgb": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-3.0.0.tgz",
-      "integrity": "sha512-iWOUTZu7KQGhErV8JfTQDH5F/M2D0HVd0sexS4Grg4e4RYAiN3c4jfpPqKgfedqeebKcNZBl2z3zlgCtFjpFJQ=="
     },
     "hoist-non-react-statics": {
       "version": "3.3.1",
@@ -3061,9 +3066,9 @@
       "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
     },
     "iconv-lite": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
-      "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
@@ -3135,9 +3140,9 @@
       }
     },
     "inversify": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/inversify/-/inversify-5.0.5.tgz",
-      "integrity": "sha512-60QsfPz8NAU/GZqXu8hJ+BhNf/C/c+Hp0eDc6XMIJTxBiP36AQyyQKpBkOVTLWBFDQWYVHpbbEuIsHu9dLuJDA=="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/inversify/-/inversify-5.1.1.tgz",
+      "integrity": "sha512-j8grHGDzv1v+8T1sAQ+3boTCntFPfvxLCkNcxB1J8qA0lUN+fAlSyYd+RXKvaPRL4AGyPxViutBEJHNXOyUdFQ=="
     },
     "ip": {
       "version": "1.1.5",
@@ -3581,49 +3586,19 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash-es": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.20.tgz",
-      "integrity": "sha512-JD1COMZsq8maT6mnuz1UMV0jvYD0E0aUsSOdrr1/nAG3dhqQXwRRgeW0cSqH1U43INKcqxaiVIQNOUDld7gRDA=="
-    },
-    "lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
-    "lodash.mapkeys": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.mapkeys/-/lodash.mapkeys-4.6.0.tgz",
-      "integrity": "sha1-3yz6Ix18V8eorQA6va1dc9PqUZU="
-    },
-    "lodash.mergewith": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
-    },
-    "lodash.snakecase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-      "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40="
-    },
     "lodash.throttle": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
       "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
-    },
-    "lodash.transform": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.transform/-/lodash.transform-4.6.0.tgz",
-      "integrity": "sha1-EjBkIvYzJK7YSD0/ODMrX2cFR6A="
     },
     "loglevel": {
       "version": "1.6.7",
@@ -5708,6 +5683,34 @@
         "twilio-sync": "^0.12.2",
         "twilsock": "^0.5.12",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "twilio-sync": {
+          "version": "0.12.4",
+          "resolved": "https://registry.npmjs.org/twilio-sync/-/twilio-sync-0.12.4.tgz",
+          "integrity": "sha512-9kJFRXIE0kAykB6Gerxf2+hMSIrTFPenlWDo05WYU1zjz0npg62zrmrq1s/7Zff1IKe1M24b6tmU0j9h/0uvdg==",
+          "requires": {
+            "loglevel": "^1.6.3",
+            "operation-retrier": "^3.0.0",
+            "platform": "^1.3.5",
+            "twilio-notifications": "^0.5.11",
+            "twilsock": "^0.5.14",
+            "uuid": "^3.3.2"
+          }
+        },
+        "twilsock": {
+          "version": "0.5.14",
+          "resolved": "https://registry.npmjs.org/twilsock/-/twilsock-0.5.14.tgz",
+          "integrity": "sha512-rMyZiMyWRAzi6wQYRzAluRPmvosFFDQeb5fy2KisxiXYiBnTZz0F5IIIW51wnmPq4VvFdr4zp1dHp2iGIX9HTA==",
+          "requires": {
+            "javascript-state-machine": "^3.0.1",
+            "loglevel": "^1.6.3",
+            "operation-retrier": "^3.0.0",
+            "platform": "^1.3.5",
+            "uuid": "^3.2.1",
+            "ws": "^5.1.0"
+          }
+        }
       }
     },
     "twilio-mcs-client": {
@@ -5747,27 +5750,42 @@
       }
     },
     "twilio-sync": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/twilio-sync/-/twilio-sync-0.12.4.tgz",
-      "integrity": "sha512-9kJFRXIE0kAykB6Gerxf2+hMSIrTFPenlWDo05WYU1zjz0npg62zrmrq1s/7Zff1IKe1M24b6tmU0j9h/0uvdg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/twilio-sync/-/twilio-sync-0.13.0.tgz",
+      "integrity": "sha512-3SfV2zQh6B2g+Tl7McYvcLH4/2IEZShXN7Lm/7GDkNnBSCtmX8cJLd5uOE1Vrj2pCXVXD9Ty2dxJlE4cDwBwlg==",
       "requires": {
         "loglevel": "^1.6.3",
         "operation-retrier": "^3.0.0",
-        "platform": "^1.3.5",
+        "platform": "^1.3.6",
         "twilio-notifications": "^0.5.11",
-        "twilsock": "^0.5.14",
+        "twilsock": "^0.6.1",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "twilsock": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/twilsock/-/twilsock-0.6.2.tgz",
+          "integrity": "sha512-Wk60XZxwFR5ooLkSLO5CGtBBXLT7VRbyPcg49D9icUqeAgm9McVZPPDq0kxVW4R4c3k4cppd1EvuhtUEejezCw==",
+          "requires": {
+            "javascript-state-machine": "^3.0.1",
+            "loglevel": "^1.6.3",
+            "operation-retrier": "^3.0.0",
+            "platform": "^1.3.6",
+            "uuid": "^3.2.1",
+            "ws": "^5.1.0"
+          }
+        }
       }
     },
     "twilsock": {
-      "version": "0.5.14",
-      "resolved": "https://registry.npmjs.org/twilsock/-/twilsock-0.5.14.tgz",
-      "integrity": "sha512-rMyZiMyWRAzi6wQYRzAluRPmvosFFDQeb5fy2KisxiXYiBnTZz0F5IIIW51wnmPq4VvFdr4zp1dHp2iGIX9HTA==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/twilsock/-/twilsock-0.8.3.tgz",
+      "integrity": "sha512-jS7sFoecgofYiRAYvinL3cYlwqOXkgtdb81q24H8mD2DNbnTwNQ6GQNURJ5GxjTYo/iSsgQjYVUs9lJaXU1uaA==",
       "requires": {
         "javascript-state-machine": "^3.0.1",
         "loglevel": "^1.6.3",
         "operation-retrier": "^3.0.0",
-        "platform": "^1.3.5",
+        "platform": "^1.3.6",
         "uuid": "^3.2.1",
         "ws": "^5.1.0"
       }
@@ -5794,9 +5812,9 @@
       "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
     },
     "uglify-js": {
-      "version": "3.12.6",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.6.tgz",
-      "integrity": "sha512-aqWHe3DfQmZUDGWBbabZ2eQnJlQd1fKlMUu7gV+MiTuDzdgDw31bI3wA2jLLsV/hNcDP26IfyEgSVoft5+0SVw==",
+      "version": "3.13.10",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.10.tgz",
+      "integrity": "sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg==",
       "optional": true
     },
     "union-value": {
@@ -6320,9 +6338,9 @@
       "dev": true
     },
     "whatwg-fetch": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
-      "integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A=="
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
     },
     "which": {
       "version": "2.0.2",
@@ -6410,9 +6428,9 @@
       "dev": true
     },
     "yaml": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yargs": {
       "version": "13.3.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "webpack-utf8-bom": "^1.3.0"
   },
   "dependencies": {
-    "@twilio/flex-webchat-ui": "^2.7.1"
+    "@twilio/flex-webchat-ui": "^2.9.1"
   }
 }


### PR DESCRIPTION
Primary reviewer: @murilovmachado 
This upgrades `@twilio/flex-webchat-ui` to [Version 2.9.1](https://www.twilio.com/docs/flex/release-notes/webchat-ui-release-notes#v-291). The main reason for this is to upgrade handlebars to eliminate a [critical severity vulnerability](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23369).  

@murilovmachado can you please take this over and test it out while adding Ethiopia/Malawi chats?