### PR TITLE
Fix jm staging config file (syntax error on dup object literal key)

### DIFF
--- a/configurations/jm-staging.ts
+++ b/configurations/jm-staging.ts
@@ -9,10 +9,9 @@ const translations: Translations = {
   'en-US': {
     WelcomeMessage: 'Welcome to SafeSpot',
     MessageCanvasTrayContent: '',
-    MessageInputDisabledReasonHold: 'Please hold for a counselor.',
-    AutoFirstMessage: 'Incoming webchat contact from',
-    MessageInputDisabledReasonHold:
+    MessageInputDisabledReasonHold: 
       "Thank you very much for this information. We'll transfer you now. Please hold for a counsellor.",
+    AutoFirstMessage: 'Incoming webchat contact from',
   },
 };
 


### PR DESCRIPTION
## Description
This PR fixes a syntax error: a key appeared twice in an object literal (`Translations`), in the jm staging config file, causing the deployments to fail.

@dee-luo I'm merging and deploying this fix, just tagging you so you are aware. 