### PR TITLE
Ph stg config 3.8.22

### DIFF
--- a/configurations/index.ts
+++ b/configurations/index.ts
@@ -14,11 +14,12 @@ import { config as mwProd } from './mw-prod';
 import { config as jmStaging } from './jm-staging';
 import { config as jmProd } from './jm-prod';
 import { config as caStaging } from './ca-staging';
+import { config as phStaging } from './ph-staging';
 
 const rawConfig = webpack.env.CONFIG;
 checkCONFIG(rawConfig);
 
-type PresetConfig = 'dev' | 'test-staging' | 'beta' | 'zm-staging' | 'zm-prod' | 'za-staging' | 'za-prod' | 'et-staging' | 'mw-staging' | 'et-prod' | 'mw-prod' | 'jm-staging' | 'jm-prod' | 'ca-staging';
+type PresetConfig = 'dev' | 'test-staging' | 'beta' | 'zm-staging' | 'zm-prod' | 'za-staging' | 'za-prod' | 'et-staging' | 'mw-staging' | 'et-prod' | 'mw-prod' | 'jm-staging' | 'jm-prod' | 'ca-staging' | 'ph-staging';
 const config = rawConfig as PresetConfig;
 
 type ConfigMap = {
@@ -39,7 +40,8 @@ const configMap: ConfigMap = {
   'mw-prod': mwProd,
   'jm-staging': jmStaging,
   'jm-prod': jmProd,
-  'ca-staging': caStaging
+  'ca-staging': caStaging,
+  'ph-staging': phStaging
 };
 
 export const getCurrentConfig = (): Configuration => configMap[config];

--- a/configurations/ph-staging.ts
+++ b/configurations/ph-staging.ts
@@ -1,0 +1,97 @@
+import {
+  PreEngagementConfig,
+  Translations,
+  Configuration,
+  MapHelplineLanguage,
+} from './types';
+
+const accountSid = 'ACa10989d583df770649051aee1430fce9';
+const flexFlowSid = 'FO9c46399151d1c7161208997b94b8f488';
+const defaultLanguage = 'en-US';
+const captureIp = true;
+
+const translations: Translations = {
+  'en-US': {
+    MessageInputDisabledReasonHold:
+      "We'll transfer you now. Please hold for a counsellor.",
+    EntryPointTagLine: 'Chat with us',
+    PreEngagementDescription: "Let's get started",
+    Today: 'Today',
+    InputPlaceHolder: 'Type Message',
+    WelcomeMessage: 'Welcome to eProtectKids!',
+    Yesterday: 'Yesterday',
+    TypingIndicator: 'Counselor is typing',
+    MessageCanvasTrayButton: 'Start New Chat',
+    MessageCanvasTrayContent: '',
+    AutoFirstMessage: 'Incoming webchat contact from',
+    StartChat: 'Start Chat!',
+  },
+  Filipino: {
+    MessageInputDisabledReasonHold:
+      'Ita-transfer ka namin sa isang helpline responder. Maaring pakihintay',
+    EntryPointTagLine: 'Makipag-usap ka sa amin',
+    PreEngagementDescription: 'Magsimula na tayo',
+    Today: 'ngayon',
+    InputPlaceHolder: 'I-type ang Mensahe',
+    WelcomeMessage: 'welcome sa eProtectKids!',
+    Yesterday: 'kahapon',
+    TypingIndicator: 'Ang responder ay nagta-type',
+    MessageCanvasTrayButton: 'Magsimula ng Bagong Chat',
+    MessageCanvasTrayContent: '',
+    AutoFirstMessage: '',
+    StartChat: 'Simulan ang Chat!',
+  },
+};
+
+const preEngagementConfig: PreEngagementConfig = {
+  description: "Let's get started",
+  fields: [
+    {
+      label: 'Select your language',
+      type: 'SelectItem',
+      attributes: {
+        name: 'language',
+        required: true,
+        readOnly: false,
+      },
+      options: [
+        {
+          value: 'English',
+          label: '1. English',
+          selected: true,
+        },
+        {
+          value: 'Filipino',
+          label: '2. Filipino',
+          selected: false,
+        }
+      ],
+    },
+  ],
+  submitLabel: 'Start Chat!',
+};
+
+const memberDisplayOptions = {
+  yourDefaultName: 'You',
+  yourFriendlyNameOverride: false,
+  theirFriendlyNameOverride: false,
+  theirDefaultName: 'eProtectKids',
+}
+
+const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {
+  switch (helpline) {
+    default:
+      return defaultLanguage;
+  }
+};
+
+export const config: Configuration = {
+  accountSid,
+  flexFlowSid,
+  defaultLanguage,
+  translations,
+  preEngagementConfig,
+  mapHelplineLanguage,
+  memberDisplayOptions,
+  captureIp,
+};


### PR DESCRIPTION
## Description
- Create ph-staging config with languages en-US and Filipino
- Add ph-staging to index

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added
- [ ] Strings are localized

<!-- Uncomment for web client-related PRs
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
