### PR TITLE
Enable chatting based on Operating hours by helpline

### DIFF
--- a/.github/workflows/aselo_development.yml
+++ b/.github/workflows/aselo_development.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           cat <<EOT >> ./private/secret.ts
           export const API_KEY = '${{ secrets.IP_FIND_API_KEY }}';
+          export const SERVERLESS_URL = '${{ secrets.DEV_SERVERLESS_URL }}';
           EOT
       # Run a single command using the runners shell to install dependencies 
       - name: Install dependencies

--- a/.github/workflows/canada_staging.yml
+++ b/.github/workflows/canada_staging.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           cat <<EOT >> ./private/secret.ts
           export const API_KEY = '${{ secrets.IP_FIND_API_KEY }}';
+          export const SERVERLESS_URL = '${{ secrets.STG_CA_SERVERLESS_URL }}';
           EOT
       # Run a single command using the runners shell to install dependencies 
       - name: Install dependencies

--- a/.github/workflows/zambia_staging.yml
+++ b/.github/workflows/zambia_staging.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           cat <<EOT >> ./private/secret.ts
           export const API_KEY = '${{ secrets.IP_FIND_API_KEY }}';
+          export const SERVERLESS_URL = '${{ secrets.STG_ZA_SERVERLESS_URL }}';
           EOT
       # Run a single command using the runners shell to install dependencies 
       - name: Install dependencies

--- a/configurations/dev.ts
+++ b/configurations/dev.ts
@@ -71,6 +71,36 @@ const preEngagementConfig: PreEngagementConfig = {
     ],
   submitLabel: "Let's chat!"
 };
+const closedHours: PreEngagementConfig = {
+  description: "We're closed at the moment. Operating hours are 8am-6pm",
+  fields:
+    [
+      {
+        label: 'Hidden Field',
+        type: 'InputField',
+        attributes: {
+          name: '',
+          required: true,
+          readOnly: true,
+        },
+      },
+    ],
+};
+const holidayHours: PreEngagementConfig = {
+  description: "Today is a holiday. Come back tomorrow",
+  fields:
+    [
+      {
+        label: 'Hidden Field',
+        type: 'InputField',
+        attributes: {
+          name: '',
+          required: true,
+          readOnly: true,
+        },
+      },
+    ],
+};
 
 const mapHelplineLanguage: MapHelplineLanguage = helpline => {
   switch (helpline) {
@@ -87,6 +117,8 @@ export const config: Configuration = {
   defaultLanguage,
   translations,
   preEngagementConfig,
+  closedHours,
+  holidayHours,
   mapHelplineLanguage,
   captureIp,
 };

--- a/configurations/dev.ts
+++ b/configurations/dev.ts
@@ -71,6 +71,7 @@ const preEngagementConfig: PreEngagementConfig = {
     ],
   submitLabel: "Let's chat!"
 };
+
 const closedHours: PreEngagementConfig = {
   description: "We're closed at the moment. Operating hours are 8am-6pm",
   fields:
@@ -86,8 +87,9 @@ const closedHours: PreEngagementConfig = {
       },
     ],
 };
+
 const holidayHours: PreEngagementConfig = {
-  description: "Today is a holiday. Come back tomorrow",
+  description: "We are closed because it is a holiday. Please come back tomorrow",
   fields:
     [
       {

--- a/configurations/dev.ts
+++ b/configurations/dev.ts
@@ -4,6 +4,8 @@ const accountSid = 'ACd8a2e89748318adf6ddff7df6948deaf';
 const flexFlowSid = 'FO8c2d9c388e7feba8b08d06a4bc3f69d1';
 const defaultLanguage = 'en-US';
 const captureIp = true;
+const checkOpenHours=true;
+
 
 const translations: Translations = {
   'en-US': {
@@ -121,6 +123,7 @@ export const config: Configuration = {
   preEngagementConfig,
   closedHours,
   holidayHours,
+  checkOpenHours,
   mapHelplineLanguage,
   captureIp,
 };

--- a/configurations/dev.ts
+++ b/configurations/dev.ts
@@ -4,8 +4,7 @@ const accountSid = 'ACd8a2e89748318adf6ddff7df6948deaf';
 const flexFlowSid = 'FO8c2d9c388e7feba8b08d06a4bc3f69d1';
 const defaultLanguage = 'en-US';
 const captureIp = true;
-const checkOpenHours=true;
-
+const checkOpenHours = true;
 
 const translations: Translations = {
   'en-US': {

--- a/configurations/types.ts
+++ b/configurations/types.ts
@@ -24,4 +24,4 @@ export type Configuration = {
   captureIp: boolean;
 };
 
-export type operatingHoursState = 'open' | 'closed' | 'holiday';
+export type OperatingHoursState = 'open' | 'closed' | 'holiday';

--- a/configurations/types.ts
+++ b/configurations/types.ts
@@ -17,7 +17,11 @@ export type Configuration = {
   defaultLanguage: string;
   translations: Translations;
   preEngagementConfig: PreEngagementConfig;
+  closedHours?: PreEngagementConfig;
+  holidayHours?: PreEngagementConfig;
   mapHelplineLanguage: MapHelplineLanguage;
   memberDisplayOptions?: MemberDisplayOptions;
   captureIp: boolean;
 };
+
+export type operatingHoursState = 'open' | 'closed' | 'holiday';

--- a/configurations/types.ts
+++ b/configurations/types.ts
@@ -22,6 +22,7 @@ export type Configuration = {
   mapHelplineLanguage: MapHelplineLanguage;
   memberDisplayOptions?: MemberDisplayOptions;
   captureIp: boolean;
+  checkOpenHours?: boolean;
 };
 
 export type OperatingHoursState = 'open' | 'closed' | 'holiday';

--- a/private/secret.example.ts
+++ b/private/secret.example.ts
@@ -1,4 +1,5 @@
 /**
- * Create a local file named 'secret.ts' that exports an API_KEY
+ * Create a local file named 'secret.ts' that exports an API_KEY and SERVERLESS_URL
  */
 export const API_KEY = 'xxxxxxxxxxxxxxxxx'; // IP Find API Key
+export const SERVERLESS_URL = 'https://serverlexxxxxxxx-xxx.twil.io'

--- a/src/aselo-webchat.ts
+++ b/src/aselo-webchat.ts
@@ -95,12 +95,12 @@ export const initWebchat = async () => {
     }
   };
 
+
   const webchat = await FlexWebChat.createWebChat(appConfig);
   const { manager } = webchat;
-
   
   // If a helpline has operating hours configuration set, the pre engagement config will show alternative canvas during closed or holiday times/days
-  const checkOperatingHours = async (): Promise<any> => {
+  const displayOperatingHours = async (): Promise<any> => {
     const operatingState = await getOperatingHours();
     if (operatingState === 'closed' && currentConfig.closedHours) {
       const preEngagementConfig = currentConfig.closedHours;
@@ -110,8 +110,15 @@ export const initWebchat = async () => {
       manager.updateConfig({ ...appConfig, preEngagementConfig });
     }
   };
-  checkOperatingHours();
-  
+
+  if (currentConfig.checkOpenHours){
+    try {
+      displayOperatingHours();
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
   const changeLanguageWebChat = getChangeLanguageWebChat(manager);
 
   changeLanguageWebChat(initialLanguage);

--- a/src/aselo-webchat.ts
+++ b/src/aselo-webchat.ts
@@ -3,6 +3,22 @@ import { Channel } from 'twilio-chat/lib/channel';
 import { getUserIp } from './ip-tracker';
 import { getCurrentConfig } from '../configurations';
 import { updateZIndex } from './dom-utils';
+import { operatingHoursState } from '../configurations/types';
+// const outOfHours: PreEngagementConfig = {
+//   description: "We're closed at the moment. Operating hours: 8am-6pm",
+//   fields:
+//     [
+//       {
+//         label: 'Hidden Field',
+//         type: 'InputField',
+//         attributes: {
+//           name: '',
+//           required: true,
+//           readOnly: true,
+//         },
+//       },
+//     ],
+// };
 
 updateZIndex();
 
@@ -10,7 +26,7 @@ const currentConfig = getCurrentConfig();
 const defaultLanguage = currentConfig.defaultLanguage;
 const initialLanguage = defaultLanguage;
 const translations = currentConfig.translations;
-
+console.log('>>currentConfig,', currentConfig)
 const getChangeLanguageWebChat = (manager: FlexWebChat.Manager) => (language: string) => {
   const twilioStrings = { ...manager.strings }; // save the originals
   const setNewStrings = (newStrings: FlexWebChat.Strings) => (manager.strings = { ...manager.strings, ...newStrings });
@@ -96,6 +112,20 @@ export const initWebchat = async () => {
 
   const webchat = await FlexWebChat.createWebChat(appConfig);
   const { manager } = webchat;
+
+  // If a helpline has operating hours configuration set, the pre engagement config will show alternative canvas during closed or holiday times/days
+  const changePreConfig = (operatingState: operatingHoursState) =>{
+    if (operatingState === 'closed'){
+      const preEngagementConfig = currentConfig.closedHours
+      manager.updateConfig({...appConfig, preEngagementConfig})
+    } else if(operatingState === 'holiday'){
+      const preEngagementConfig = currentConfig.holidayHours
+      manager.updateConfig({...appConfig, preEngagementConfig})
+    }
+  }
+
+  changePreConfig('open')
+  
   const changeLanguageWebChat = getChangeLanguageWebChat(manager);
 
   changeLanguageWebChat(initialLanguage);

--- a/src/operating-hours.ts
+++ b/src/operating-hours.ts
@@ -1,0 +1,32 @@
+import { SERVERLESS_URL } from '../private/secret';
+import { OperatingHoursState } from '../configurations/types';
+
+
+export const getOperatingHours = async (): Promise<OperatingHoursState> => {
+  const body = { channel: 'webchat' };
+
+  const options = {
+    method: 'POST',
+    body: new URLSearchParams({ ...body }),
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+    },
+  };
+
+  const response = await fetch(`${SERVERLESS_URL}/operatingHours`, options);
+
+  if (response.status === 403) {
+    throw new Error('Server responded with 403 status (Forbidden)');
+  }
+
+  const responseJson = await response.json();
+
+  if (!response.ok) {
+    const option = responseJson.stack ? { cause: responseJson.stack } : null;
+    console.log('Error:', option);
+    throw new Error(responseJson.message);
+  }
+
+  return responseJson;
+};
+


### PR DESCRIPTION
Primary Reviewer: @GPaoloni 

## Description
- Added  logic to call `/operatingHours` serverless function
- Added new `closedHours` and `holidayHours` PreEngagementConfig and `checkOpeHours` flag to `dev.ts` configuration
- Added `displayOperatingHours` function to enable /disable chatting leveraging the operatingHours twilio function based on each helpline flag that have a requirement for states other than 'open'(user can chat).

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes # [1236](https://bugs.benetech.org/browse/CHI-1236)

### Verification steps
- First, operatingHours function has be public - check this [PR](https://github.com/techmatters/serverless/pull/268)
- In `private/secret.ts`, set SERVERLESS_URL to dev serverless url