### PR TITLE
Add style override to utilize line breaks in pre engagement component

### DIFF
--- a/src/aselo-webchat.ts
+++ b/src/aselo-webchat.ts
@@ -92,7 +92,21 @@ export const initWebchat = async () => {
     preEngagementConfig: currentConfig.preEngagementConfig,
     context: {
       ip,
-    }
+    },
+    colorTheme: {
+      overrides: {
+        PreEngagementCanvas: {
+          Container: {
+            ':first-child': {
+              'white-space': 'break-spaces',
+            },
+          },
+          Form: {
+            Label: { display: 'block' },
+          },
+        },
+      },
+    },
   };
 
 


### PR DESCRIPTION
Primary Reviewer: @murilovmachado 

## Description
- Add style override to utilize line breaks in pre engagement component

### Checklist
- [n/a] Corresponding issue has been opened
- [n/a] New tests added

### Verification steps
- In a description of a definition of type PreEngagementConfig, using `/n` will add a line break instead of simply a non breaking space.
