### PR TITLE
Remove import, and use 'require' for using serverless url for getOperatingHours

### DIFF
--- a/src/operating-hours.ts
+++ b/src/operating-hours.ts
@@ -1,6 +1,4 @@
-import { SERVERLESS_URL } from '../private/secret';
 import { OperatingHoursState } from '../configurations/types';
-
 
 export const getOperatingHours = async (): Promise<OperatingHoursState> => {
   const body = { channel: 'webchat' };
@@ -13,6 +11,7 @@ export const getOperatingHours = async (): Promise<OperatingHoursState> => {
     },
   };
 
+  const {SERVERLESS_URL} = require('../private/secret')
   const response = await fetch(`${SERVERLESS_URL}/operatingHours`, options);
 
   if (response.status === 403) {


### PR DESCRIPTION
Reviewer: @GPaoloni 

## Description
- Change to `require` serverless url instead of `import` to mitigate build error in workflow

### Verification steps
- This should fix failing helpline deploys
