### PR TITLE
Apply IP address block for Jamaica

### DIFF
--- a/configurations/jm-staging.ts
+++ b/configurations/jm-staging.ts
@@ -47,6 +47,10 @@ const memberDisplayOptions = {
   theirDefaultName: 'SafeSpot Counsellor',
 }
 
+const blockedIps = [
+  '74.115.77.64',
+];
+
 export const config: Configuration = {
   accountSid,
   flexFlowSid,
@@ -56,4 +60,5 @@ export const config: Configuration = {
   mapHelplineLanguage,
   memberDisplayOptions,
   captureIp,
+  blockedIps,
 };

--- a/configurations/types.ts
+++ b/configurations/types.ts
@@ -22,6 +22,7 @@ export type Configuration = {
   mapHelplineLanguage: MapHelplineLanguage;
   memberDisplayOptions?: MemberDisplayOptions;
   captureIp: boolean;
+  blockedIps?: string[];
   checkOpenHours?: boolean;
 };
 

--- a/src/aselo-webchat.ts
+++ b/src/aselo-webchat.ts
@@ -85,6 +85,11 @@ export const initWebchat = async () => {
     ip = await getUserIp();
   }
 
+  if (Array.isArray(currentConfig.blockedIps) && ip && currentConfig.blockedIps.includes(ip)) {
+    window.alert('You are blocked :)');
+    return;
+  }
+
   const appConfig = {
     accountSid: currentConfig.accountSid,
     flexFlowSid: currentConfig.flexFlowSid,
@@ -108,7 +113,6 @@ export const initWebchat = async () => {
       },
     },
   };
-
 
   const webchat = await FlexWebChat.createWebChat(appConfig);
   const { manager } = webchat;

--- a/src/aselo-webchat.ts
+++ b/src/aselo-webchat.ts
@@ -86,7 +86,6 @@ export const initWebchat = async () => {
   }
 
   if (Array.isArray(currentConfig.blockedIps) && ip && currentConfig.blockedIps.includes(ip)) {
-    window.alert('You are blocked :)');
     return;
   }
 


### PR DESCRIPTION
## Description
Blocks the IP of the abusive contact as requested. This is done in a very naive way, but will suffice until we implement https://bugs.benetech.org/browse/CHI-1325. 

### Checklist
- [x] [Corresponding issue has been opened](https://bugs.benetech.org/browse/CHI-1356)
- [ ] New tests added

### Verification steps
- Get your ip address.
- Add it to the `dev` config, like
```
const blockedIps = [yourIp];
export const config: Configuration = {
  ....
  blockedIps,
};
```
- `npm start` and check that the widget does not loads for you.