### PR TITLE
Adds End Chat Button to UI and call to endChat serverless function

### DIFF
--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import * as FlexWebChat from '@twilio/flex-webchat-ui';
 import { Channel } from 'twilio-chat/lib/channel';
 
@@ -8,7 +8,6 @@ import { getCurrentConfig } from '../configurations';
 import { updateZIndex } from './dom-utils';
 import blockedIps from './blockedIps.json';
 import EndChat from './components/EndChatButton';
-import { EngagementStage } from '@twilio/flex-webchat-ui/src/constants/session';
 
 updateZIndex();
 
@@ -177,15 +176,14 @@ export const initWebchat = async () => {
 
     setChannelAfterStartEngagement(manager, ip);
   });
-  
+
   // Render WebChat
   webchat.init();
-  
-  const { channelSid, tokenPayload, engagementStage } = manager.store.getState().flex.session;
-  const { token } = tokenPayload;
-  
-  if (engagementStage === 'CF_IN_ENGAGEMENT'){
-    FlexWebChat.MessageList.Content.add(<EndChat key="endchat" channelSid={channelSid} token={token} />);
-  }
 
+  const {
+    channelSid,
+    tokenPayload: { token },
+  } = manager.store.getState().flex.session;
+
+  FlexWebChat.MessageList.Content.add(<EndChat key="endchat" channelSid={channelSid} token={token} />);
 };

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -8,6 +8,7 @@ import { getCurrentConfig } from '../configurations';
 import { updateZIndex } from './dom-utils';
 import blockedIps from './blockedIps.json';
 import EndChat from './components/EndChatButton';
+import { EngagementStage } from '@twilio/flex-webchat-ui/src/constants/session';
 
 updateZIndex();
 
@@ -176,12 +177,15 @@ export const initWebchat = async () => {
 
     setChannelAfterStartEngagement(manager, ip);
   });
-
+  
   // Render WebChat
   webchat.init();
-
-  const { channelSid, tokenPayload } = manager.store.getState().flex.session;
+  
+  const { channelSid, tokenPayload, engagementStage } = manager.store.getState().flex.session;
   const { token } = tokenPayload;
+  
+  if (engagementStage === 'CF_IN_ENGAGEMENT'){
+    FlexWebChat.MessageList.Content.add(<EndChat key="endchat" channelSid={channelSid} token={token} />);
+  }
 
-  FlexWebChat.MessageList.Content.add(<EndChat key="endchat" token={token} />);
 };

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -7,7 +7,7 @@ import { getOperatingHours } from './operating-hours';
 import { getCurrentConfig } from '../configurations';
 import { updateZIndex } from './dom-utils';
 import blockedIps from './blockedIps.json';
-import Test from './components/Test';
+import EndChat from './components/EndChatButton';
 
 updateZIndex();
 
@@ -180,8 +180,8 @@ export const initWebchat = async () => {
   // Render WebChat
   webchat.init();
 
-  const enableExitButtons = false;
-  if (enableExitButtons) {
-    FlexWebChat.MessageList.Content.add(<Test key="test" />);
-  }
+  const { channelSid, tokenPayload } = manager.store.getState().flex.session;
+  const { token } = tokenPayload;
+
+  FlexWebChat.MessageList.Content.add(<EndChat key="endchat" token={token} />);
 };

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -81,6 +81,15 @@ const setChannelAfterStartEngagement = doWithChannel(
   },
 );
 
+const setEndChatButton = (manager: FlexWebChat.Manager) => {
+  const {
+    channelSid,
+    tokenPayload: { token },
+  } = manager.store.getState().flex.session;
+
+  FlexWebChat.MessageList.Content.add(<EndChat key="endChat" channelSid={channelSid} token={token} />);
+};
+
 export const initWebchat = async () => {
   let ip: string | undefined;
 
@@ -180,10 +189,5 @@ export const initWebchat = async () => {
   // Render WebChat
   webchat.init();
 
-  const {
-    channelSid,
-    tokenPayload: { token },
-  } = manager.store.getState().flex.session;
-
-  FlexWebChat.MessageList.Content.add(<EndChat key="endchat" channelSid={channelSid} token={token} />);
+  setEndChatButton(manager);
 };

--- a/src/components/EndChatButton.tsx
+++ b/src/components/EndChatButton.tsx
@@ -5,15 +5,16 @@ import { endChat } from '../serverless-calls/endChat';
 
 type Props = {
   token: string;
+  channelSid: string;
 };
 
-export default function EndChat({ token }: Props) {
+export default function EndChat({ channelSid, token }: Props) {
   const handleEndChat = async () => {
-  console.log('>handleEndChat start call to endChat')
-
-    await endChat(token);
-  console.log('>handleEndChat end call to endChat')
-
+    try {
+      await endChat(channelSid, token);
+    } catch (error) {
+      console.log(error);
+    }
   };
   return (
     <button type="button" onClick={handleEndChat}>

--- a/src/components/EndChatButton.tsx
+++ b/src/components/EndChatButton.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import * as FlexWebChat from '@twilio/flex-webchat-ui';
+
+import { endChat } from '../serverless-calls/endChat';
+
+type Props = {
+  token: string;
+};
+
+export default function EndChat({ token }: Props) {
+  const handleEndChat = async () => {
+  console.log('>handleEndChat start call to endChat')
+
+    await endChat(token);
+  console.log('>handleEndChat end call to endChat')
+
+  };
+  return (
+    <button type="button" onClick={handleEndChat}>
+      End Chat
+    </button>
+  );
+}

--- a/src/components/EndChatButton.tsx
+++ b/src/components/EndChatButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { endChat } from '../serverless-calls/endChat';
 
 type Props = {

--- a/src/components/EndChatButton.tsx
+++ b/src/components/EndChatButton.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import * as FlexWebChat from '@twilio/flex-webchat-ui';
-
 import { endChat } from '../serverless-calls/endChat';
 
 type Props = {

--- a/src/components/Test.tsx
+++ b/src/components/Test.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function Test() {
-  return <div>test</div>;
-}

--- a/src/serverless-calls/endChat.ts
+++ b/src/serverless-calls/endChat.ts
@@ -1,0 +1,30 @@
+type Token = string;
+
+export const endChat = async (token: Token): Promise<Token> => {
+  const body = { Token: token };
+
+  const options = {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  };
+  // eslint-disable-next-line global-require
+  const { SERVERLESS_URL } = require('../../private/secret');
+  const response = await fetch(`${SERVERLESS_URL}/endChat`, options)
+  const responseJson = await response.json();
+  
+  if (response.status === 403) {
+    throw new Error('Server responded with 403 status (Forbidden)');
+  }
+  
+  if (!response.ok) {
+    const option = responseJson.stack ? { cause: responseJson.stack } : null;
+    console.log('Error:', option);
+    throw new Error(responseJson.message);
+  }
+  
+  console.log('>responseJson', responseJson)
+  return responseJson;
+};

--- a/src/serverless-calls/endChat.ts
+++ b/src/serverless-calls/endChat.ts
@@ -1,7 +1,8 @@
 type Token = string;
+type ChannelSid = string;
 
-export const endChat = async (token: Token): Promise<Token> => {
-  const body = { Token: token };
+export const endChat = async (channelSid: ChannelSid, token: Token): Promise<Token> => {
+  const body = { channelSid, Token: token };
 
   const options = {
     method: 'POST',
@@ -12,19 +13,18 @@ export const endChat = async (token: Token): Promise<Token> => {
   };
   // eslint-disable-next-line global-require
   const { SERVERLESS_URL } = require('../../private/secret');
-  const response = await fetch(`${SERVERLESS_URL}/endChat`, options)
+  const response = await fetch(`${SERVERLESS_URL}/endChat`, options);
   const responseJson = await response.json();
-  
+
   if (response.status === 403) {
     throw new Error('Server responded with 403 status (Forbidden)');
   }
-  
+
   if (!response.ok) {
     const option = responseJson.stack ? { cause: responseJson.stack } : null;
     console.log('Error:', option);
     throw new Error(responseJson.message);
   }
-  
-  console.log('>responseJson', responseJson)
+
   return responseJson;
 };


### PR DESCRIPTION
Primary Reviewer: @GPaoloni 

## Description
- Added an 'End Chat' button that will trigger the endChat serverless function and change the task assignment to wrapping, ending the conversation
- Added call to endChat serverless function

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added

### Related Issues
Fixes #[1402](https://bugs.benetech.org/projects/CHI/issues/CHI-1402) partially. See [PR](https://github.com/techmatters/serverless/pull/323)

### Verification steps
- Add Aselo production serverless url to secret
- Run webchat locally while this serverless PR's version is deployed in production in Aselo Development
