### PR TITLE
Quick Exit Button should end chat, report to counsellor in flex(when task is assigned)

### DIFF
--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -3,7 +3,7 @@ import * as FlexWebChat from '@twilio/flex-webchat-ui';
 import { Channel } from 'twilio-chat/lib/channel';
 
 import { getUserIp } from './ip-tracker';
-import { getOperatingHours } from './operating-hours';
+import { getOperatingHours } from './serverless-calls/operating-hours';
 import { getCurrentConfig } from '../configurations';
 import { updateZIndex } from './dom-utils';
 import blockedIps from './blockedIps.json';
@@ -81,12 +81,15 @@ const setChannelAfterStartEngagement = doWithChannel(
   },
 );
 
-const closeChat = (manager: FlexWebChat.Manager) => {
+const displayCloseButtons = (manager: FlexWebChat.Manager) => {
   const {
     channelSid,
     tokenPayload: { token },
   } = manager.store.getState().flex.session;
-  FlexWebChat.MessageList.Content.add(<CloseChatButtons key="closeChat" channelSid={channelSid} token={token} />);
+
+  if (channelSid !== null && token !== null) {
+    FlexWebChat.MessageList.Content.add(<CloseChatButtons key="closechat" channelSid={channelSid} token={token} />);
+  }
 };
 
 export const initWebchat = async () => {
@@ -188,5 +191,5 @@ export const initWebchat = async () => {
   // Render WebChat
   webchat.init();
 
-  closeChat(manager);
+  displayCloseButtons(manager);
 };

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import * as FlexWebChat from '@twilio/flex-webchat-ui';
 import { Channel } from 'twilio-chat/lib/channel';
 
@@ -85,7 +85,6 @@ const closeChat = (manager: FlexWebChat.Manager) => {
   const {
     channelSid,
     tokenPayload: { token },
-    engagementStage,
   } = manager.store.getState().flex.session;
   FlexWebChat.MessageList.Content.add(<CloseChatButtons key="closeChat" channelSid={channelSid} token={token} />);
 };

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -7,7 +7,7 @@ import { getOperatingHours } from './operating-hours';
 import { getCurrentConfig } from '../configurations';
 import { updateZIndex } from './dom-utils';
 import blockedIps from './blockedIps.json';
-import EndChat from './components/EndChatButton';
+import CloseChatButtons from './components/CloseChatButtons';
 
 updateZIndex();
 
@@ -81,13 +81,13 @@ const setChannelAfterStartEngagement = doWithChannel(
   },
 );
 
-const setEndChatButton = (manager: FlexWebChat.Manager) => {
+const closeChat = (manager: FlexWebChat.Manager) => {
   const {
     channelSid,
     tokenPayload: { token },
+    engagementStage,
   } = manager.store.getState().flex.session;
-
-  FlexWebChat.MessageList.Content.add(<EndChat key="endChat" channelSid={channelSid} token={token} />);
+  FlexWebChat.MessageList.Content.add(<CloseChatButtons key="closeChat" channelSid={channelSid} token={token} />);
 };
 
 export const initWebchat = async () => {
@@ -189,5 +189,5 @@ export const initWebchat = async () => {
   // Render WebChat
   webchat.init();
 
-  setEndChatButton(manager);
+  closeChat(manager);
 };

--- a/src/components/CloseChatButtons.tsx
+++ b/src/components/CloseChatButtons.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { EngagementStage } from '@twilio/flex-webchat-ui/src/constants/session';
 
 import Exit from './QuickExitButton';
 import End from './EndChatButton';

--- a/src/components/CloseChatButtons.tsx
+++ b/src/components/CloseChatButtons.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { EngagementStage } from '@twilio/flex-webchat-ui/src/constants/session';
+
+import Exit from './QuickExitButton';
+import End from './EndChatButton';
+
+// Buttons should be able to end the conversation and notify the counselor that the child has left the conversation
+type Props = {
+  channelSid: string;
+  token: string;
+};
+export default function CloseChatButtons({ channelSid, token }: Props) {
+  return (
+    <div style={{ margin: '3px auto' }}>
+      <Exit channelSid={channelSid} token={token} />
+      <End channelSid={channelSid} token={token} />
+    </div>
+  );
+}

--- a/src/components/CloseChatButtons.tsx
+++ b/src/components/CloseChatButtons.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import Exit from './QuickExitButton';
 import End from './EndChatButton';
 
-// Buttons should be able to end the conversation and notify the counselor that the child has left the conversation
 type Props = {
   channelSid: string;
   token: string;

--- a/src/components/EndChatButton.tsx
+++ b/src/components/EndChatButton.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 import { endChat } from '../serverless-calls/endChat';
 
 type Props = {
-  token: string;
   channelSid: string;
+  token: string;
 };
 
 export default function EndChat({ channelSid, token }: Props) {

--- a/src/components/QuickExitButton.tsx
+++ b/src/components/QuickExitButton.tsx
@@ -4,8 +4,8 @@ import * as FlexWebChat from '@twilio/flex-webchat-ui';
 import { endChat } from '../serverless-calls/endChat';
 
 type Props = {
-  token: string;
   channelSid: string;
+  token: string;
 };
 
 export default function EndChat({ channelSid, token }: Props) {
@@ -13,23 +13,16 @@ export default function EndChat({ channelSid, token }: Props) {
   const handleEndChat = async () => {
     try {
       await endChat(channelSid, token);
-      console.log('await endChat');
     } catch (error) {
       console.log(error);
     }
   };
 
-  // This is a webchat api call to clear the history and open a new window
   const handleExit = async () => {
     await handleEndChat();
-    try {
-      FlexWebChat.Actions.invokeAction('RestartEngagement');
-      window.close();
-
-      window.open('https://google.com');
-    } catch (error) {
-      console.log(error);
-    }
+    // Clear chat history and open a new location
+    await FlexWebChat.Actions.invokeAction('RestartEngagement');
+    setTimeout(() => window.open('https://google.com', '_self'), 1000);
   };
 
   return (

--- a/src/components/QuickExitButton.tsx
+++ b/src/components/QuickExitButton.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import * as FlexWebChat from '@twilio/flex-webchat-ui';
 
 import { endChat } from '../serverless-calls/endChat';

--- a/src/components/QuickExitButton.tsx
+++ b/src/components/QuickExitButton.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect } from 'react';
+import * as FlexWebChat from '@twilio/flex-webchat-ui';
+
+import { endChat } from '../serverless-calls/endChat';
+
+type Props = {
+  token: string;
+  channelSid: string;
+};
+
+export default function EndChat({ channelSid, token }: Props) {
+  // Serverless call to end chat
+  const handleEndChat = async () => {
+    try {
+      await endChat(channelSid, token);
+      console.log('await endChat');
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  // This is a webchat api call to clear the history and open a new window
+  const handleExit = async () => {
+    await handleEndChat();
+    try {
+      FlexWebChat.Actions.invokeAction('RestartEngagement');
+      window.close();
+
+      window.open('https://google.com');
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  return (
+    <button type="button" onClick={handleExit}>
+      Quick Exit
+    </button>
+  );
+}

--- a/src/serverless-calls/operating-hours.ts
+++ b/src/serverless-calls/operating-hours.ts
@@ -1,4 +1,4 @@
-import { OperatingHoursState } from '../configurations/types';
+import { OperatingHoursState } from '../../configurations/types';
 
 export const getOperatingHours = async (): Promise<OperatingHoursState> => {
   const body = { channel: 'webchat' };
@@ -11,7 +11,7 @@ export const getOperatingHours = async (): Promise<OperatingHoursState> => {
     },
   };
 
-  const { SERVERLESS_URL } = require('../private/secret'); // eslint-disable-line global-require
+  const { SERVERLESS_URL } = require('../../private/secret'); // eslint-disable-line global-require
   const response = await fetch(`${SERVERLESS_URL}/operatingHours`, options);
 
   if (response.status === 403) {


### PR DESCRIPTION
## Description
- Quick Exit Button should end chat, report to counsellor in flex(when task is in assignedState) and wrap the task or cancel in reserved, and clear history
- Restructured folders for UI components and server-less calls

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

### Related Issues
Fixes # [CHI-1404](https://bugs.benetech.org/browse/CHI-1404)

### Verification steps
- Test 'Quick Chat' button. This should wrap the chat in flex and clear history. Opening webchat again should be in a new state.
