### PR TITLE
Send language to localize EndChatMessage for use in serverless

### DIFF
--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -14,7 +14,6 @@ updateZIndex();
 
 const currentConfig = getCurrentConfig();
 const { defaultLanguage, translations } = currentConfig;
-console.log('>> currentConfig',{currentConfig})
 const initialLanguage = defaultLanguage;
 
 const getChangeLanguageWebChat = (manager: FlexWebChat.Manager) => (language: string) => {

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -14,6 +14,7 @@ updateZIndex();
 
 const currentConfig = getCurrentConfig();
 const { defaultLanguage, translations } = currentConfig;
+console.log('>> currentConfig',{currentConfig})
 const initialLanguage = defaultLanguage;
 
 const getChangeLanguageWebChat = (manager: FlexWebChat.Manager) => (language: string) => {

--- a/src/components/CloseChatButtons.tsx
+++ b/src/components/CloseChatButtons.tsx
@@ -7,7 +7,7 @@ import Exit from './QuickExitButton';
 import End from './EndChatButton';
 
 const CloseChatButtons = ({ channelSid, token, language }: MapStateToProps) => {
-  if (!channelSid || !token || !language) {
+  if (!channelSid || !token) {
     return null;
   }
   return (

--- a/src/components/CloseChatButtons.tsx
+++ b/src/components/CloseChatButtons.tsx
@@ -10,7 +10,7 @@ const CloseChatButtons = ({ channelSid, token, language }: MapStateToProps) => {
   if (!channelSid || !token || !language) {
     return null;
   }
-
+console.log('laguage', language)
   return (
     <div>
       <Exit channelSid={channelSid} token={token} language={language}/>

--- a/src/components/CloseChatButtons.tsx
+++ b/src/components/CloseChatButtons.tsx
@@ -10,11 +10,10 @@ const CloseChatButtons = ({ channelSid, token, language }: MapStateToProps) => {
   if (!channelSid || !token || !language) {
     return null;
   }
-console.log('laguage', language)
   return (
-    <div>
-      <Exit channelSid={channelSid} token={token} language={language}/>
-      <End channelSid={channelSid} token={token} language={language}/>
+    <div style={{ margin: '3px auto' }}>
+      <Exit channelSid={channelSid} token={token} language={language} />
+      <End channelSid={channelSid} token={token} language={language} />
     </div>
   );
 };

--- a/src/components/CloseChatButtons.tsx
+++ b/src/components/CloseChatButtons.tsx
@@ -6,15 +6,15 @@ import * as FlexWebChat from '@twilio/flex-webchat-ui';
 import Exit from './QuickExitButton';
 import End from './EndChatButton';
 
-const CloseChatButtons = ({ channelSid, token }: MapStateToProps) => {
-  if (!channelSid || !token) {
+const CloseChatButtons = ({ channelSid, token, language }: MapStateToProps) => {
+  if (!channelSid || !token || !language) {
     return null;
   }
 
   return (
-    <div style={{ margin: '3px auto' }}>
-      <Exit channelSid={channelSid} token={token} />
-      <End channelSid={channelSid} token={token} />
+    <div>
+      <Exit channelSid={channelSid} token={token} language={language}/>
+      <End channelSid={channelSid} token={token} language={language}/>
     </div>
   );
 };
@@ -22,6 +22,7 @@ const CloseChatButtons = ({ channelSid, token }: MapStateToProps) => {
 type MapStateToProps = {
   channelSid?: string;
   token?: string;
+  language?: string;
 };
 
 type FlexState = {
@@ -31,6 +32,7 @@ type FlexState = {
 const mapStateToProps = (state: FlexState) => ({
   channelSid: state?.flex?.session?.channelSid,
   token: state?.flex?.session?.tokenPayload?.token,
+  language: state?.flex?.config?.language,
 });
 
 export default connect(mapStateToProps)(CloseChatButtons);

--- a/src/components/EndChatButton.tsx
+++ b/src/components/EndChatButton.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/require-default-props */
 import React from 'react';
 
 import { endChat } from '../serverless-calls/endChat';
@@ -5,7 +6,7 @@ import { endChat } from '../serverless-calls/endChat';
 type Props = {
   channelSid: string;
   token: string;
-  language: string;
+  language?: string;
 };
 
 export default function EndChat({ channelSid, token, language }: Props) {

--- a/src/components/EndChatButton.tsx
+++ b/src/components/EndChatButton.tsx
@@ -5,12 +5,13 @@ import { endChat } from '../serverless-calls/endChat';
 type Props = {
   channelSid: string;
   token: string;
+  language: string;
 };
 
-export default function EndChat({ channelSid, token }: Props) {
+export default function EndChat({ channelSid, token, language }: Props) {
   const handleEndChat = async () => {
     try {
-      await endChat(channelSid, token);
+      await endChat(channelSid, token, language);
     } catch (error) {
       console.log(error);
     }

--- a/src/components/QuickExitButton.tsx
+++ b/src/components/QuickExitButton.tsx
@@ -6,7 +6,7 @@ import { endChat } from '../serverless-calls/endChat';
 type Props = {
   channelSid: string;
   token: string;
-  language:string;
+  language: string;
 };
 
 export default function EndChat({ channelSid, token, language }: Props) {

--- a/src/components/QuickExitButton.tsx
+++ b/src/components/QuickExitButton.tsx
@@ -6,13 +6,14 @@ import { endChat } from '../serverless-calls/endChat';
 type Props = {
   channelSid: string;
   token: string;
+  language:string;
 };
 
-export default function EndChat({ channelSid, token }: Props) {
+export default function EndChat({ channelSid, token, language }: Props) {
   // Serverless call to end chat
   const handleEndChat = async () => {
     try {
-      await endChat(channelSid, token);
+      await endChat(channelSid, token, language);
     } catch (error) {
       console.log(error);
     }

--- a/src/components/QuickExitButton.tsx
+++ b/src/components/QuickExitButton.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/require-default-props */
 import React from 'react';
 import * as FlexWebChat from '@twilio/flex-webchat-ui';
 
@@ -6,7 +7,7 @@ import { endChat } from '../serverless-calls/endChat';
 type Props = {
   channelSid: string;
   token: string;
-  language: string;
+  language?: string;
 };
 
 export default function EndChat({ channelSid, token, language }: Props) {

--- a/src/serverless-calls/endChat.ts
+++ b/src/serverless-calls/endChat.ts
@@ -2,7 +2,7 @@ type Token = string;
 type ChannelSid = string;
 type Language = string;
 
-export const endChat = async (channelSid: ChannelSid, token: Token, language:Language): Promise<Token> => {
+export const endChat = async (channelSid: ChannelSid, token: Token, language: Language): Promise<Token> => {
   const body = { channelSid, Token: token, language };
 
   const options = {

--- a/src/serverless-calls/endChat.ts
+++ b/src/serverless-calls/endChat.ts
@@ -2,7 +2,7 @@ type Token = string;
 type ChannelSid = string;
 type Language = string;
 
-export const endChat = async (channelSid: ChannelSid, token: Token, language: Language): Promise<Token> => {
+export const endChat = async (channelSid: ChannelSid, token: Token, language?: Language): Promise<Token> => {
   const body = { channelSid, Token: token, language };
 
   const options = {

--- a/src/serverless-calls/endChat.ts
+++ b/src/serverless-calls/endChat.ts
@@ -1,8 +1,9 @@
 type Token = string;
 type ChannelSid = string;
+type Language = string;
 
-export const endChat = async (channelSid: ChannelSid, token: Token): Promise<Token> => {
-  const body = { channelSid, Token: token };
+export const endChat = async (channelSid: ChannelSid, token: Token, language:Language): Promise<Token> => {
+  const body = { channelSid, Token: token, language };
 
   const options = {
     method: 'POST',


### PR DESCRIPTION
Primary Reviewer: @GPaoloni or @stephenhand

## Description

- This PR adds `language` from config object to redux state and subsequently use this as a request parameter for endChat function 
- [serverless PR](https://github.com/techmatters/serverless/pull/348)

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #1402

### Verification steps
- Ensuring this branch in [PR](https://github.com/techmatters/serverless/pull/348) is deployed, in webchat (local or deployed dev), get to the part where 'End Chat' can be triggered. Check the Bot message
- Alternatively, `language` can be hardcoded to a different appropriate one and checking if the messages matches what is in assets