### PR TITLE
Add serverless urls to workflows for staging accounts

### DIFF
--- a/.github/workflows/aselo_beta.yml
+++ b/.github/workflows/aselo_beta.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           cat <<EOT >> ./private/secret.ts
           export const API_KEY = '${{ secrets.IP_FIND_API_KEY }}';
+          export const SERVERLESS_URL = '${{ secrets.BETA_SERVERLESS_URL }}';
           EOT
       # Run a single command using the runners shell to install dependencies 
       - name: Install dependencies

--- a/.github/workflows/cl_linealibre_staging.yml
+++ b/.github/workflows/cl_linealibre_staging.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           cat <<EOT >> ./private/secret.ts
           export const API_KEY = '${{ secrets.IP_FIND_API_KEY }}';
+          export const SERVERLESS_URL = '${{ secrets.STG_CL_SERVERLESS_URL }}';
           EOT
       # Run a single command using the runners shell to install dependencies 
       - name: Install dependencies

--- a/.github/workflows/ethiopia_staging.yml
+++ b/.github/workflows/ethiopia_staging.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           cat <<EOT >> ./private/secret.ts
           export const API_KEY = '${{ secrets.IP_FIND_API_KEY }}';
+          export const SERVERLESS_URL = '${{ secrets.STG_ET_SERVERLESS_URL }}';
           EOT
       # Run a single command using the runners shell to install dependencies 
       - name: Install dependencies

--- a/.github/workflows/hungary_production.yml
+++ b/.github/workflows/hungary_production.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           cat <<EOT >> ./private/secret.ts
           export const API_KEY = '${{ secrets.IP_FIND_API_KEY }}';
-          export const SERVERLESS_URL = '${{ secrets.HU_PROD_SERVERLESS_URL }}';
+          export const SERVERLESS_URL = '${{ secrets.PROD_HU_SERVERLESS_URL }}';
           EOT
       # Run a single command using the runners shell to install dependencies 
       - name: Install dependencies

--- a/.github/workflows/hungary_production.yml
+++ b/.github/workflows/hungary_production.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           cat <<EOT >> ./private/secret.ts
           export const API_KEY = '${{ secrets.IP_FIND_API_KEY }}';
+          export const SERVERLESS_URL = '${{ secrets.HU_PROD_SERVERLESS_URL }}';
           EOT
       # Run a single command using the runners shell to install dependencies 
       - name: Install dependencies

--- a/.github/workflows/hungary_staging.yml
+++ b/.github/workflows/hungary_staging.yml
@@ -29,6 +29,8 @@ jobs:
         run: |
           cat <<EOT >> ./private/secret.ts
           export const API_KEY = '${{ secrets.IP_FIND_API_KEY }}';
+          export const SERVERLESS_URL = '${{ secrets.HU_STG_SERVERLESS_URL }}';
+
           EOT
       # Run a single command using the runners shell to install dependencies 
       - name: Install dependencies

--- a/.github/workflows/hungary_staging.yml
+++ b/.github/workflows/hungary_staging.yml
@@ -29,8 +29,7 @@ jobs:
         run: |
           cat <<EOT >> ./private/secret.ts
           export const API_KEY = '${{ secrets.IP_FIND_API_KEY }}';
-          export const SERVERLESS_URL = '${{ secrets.HU_STG_SERVERLESS_URL }}';
-
+          export const SERVERLESS_URL = '${{ secrets.STG_HU_SERVERLESS_URL }}';
           EOT
       # Run a single command using the runners shell to install dependencies 
       - name: Install dependencies

--- a/.github/workflows/jamaica_staging.yml
+++ b/.github/workflows/jamaica_staging.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           cat <<EOT >> ./private/secret.ts
           export const API_KEY = '${{ secrets.IP_FIND_API_KEY }}';
+          export const SERVERLESS_URL = '${{ secrets.STG_JM_SERVERLESS_URL }}';
           EOT
       # Run a single command using the runners shell to install dependencies 
       - name: Install dependencies

--- a/.github/workflows/malawi_staging.yml
+++ b/.github/workflows/malawi_staging.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           cat <<EOT >> ./private/secret.ts
           export const API_KEY = '${{ secrets.IP_FIND_API_KEY }}';
+          export const SERVERLESS_URL = '${{ secrets.STG_MW_SERVERLESS_URL }}';
           EOT
       # Run a single command using the runners shell to install dependencies 
       - name: Install dependencies

--- a/.github/workflows/romania_staging.yml
+++ b/.github/workflows/romania_staging.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           cat <<EOT >> ./private/secret.ts
           export const API_KEY = '${{ secrets.IP_FIND_API_KEY }}';
+          export const SERVERLESS_URL = '${{ secrets.STG_RO_SERVERLESS_URL }}';
           EOT
       # Run a single command using the runners shell to install dependencies 
       - name: Install dependencies

--- a/.github/workflows/telefonzaufania_pl_staging.yml
+++ b/.github/workflows/telefonzaufania_pl_staging.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           cat <<EOT >> ./private/secret.ts
           export const API_KEY = '${{ secrets.IP_FIND_API_KEY }}';
+          export const SERVERLESS_URL = '${{ secrets.STG_PL_SERVERLESS_URL }}';
           EOT
       # Run a single command using the runners shell to install dependencies
       - name: Install dependencies

--- a/.github/workflows/uk_staging.yml
+++ b/.github/workflows/uk_staging.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           cat <<EOT >> ./private/secret.ts
           export const API_KEY = '${{ secrets.IP_FIND_API_KEY }}';
+          export const SERVERLESS_URL = '${{ secrets.STG_UK_SERVERLESS_URL }}';
           EOT
       # Run a single command using the runners shell to install dependencies 
       - name: Install dependencies

--- a/.github/workflows/zambia_staging.yml
+++ b/.github/workflows/zambia_staging.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           cat <<EOT >> ./private/secret.ts
           export const API_KEY = '${{ secrets.IP_FIND_API_KEY }}';
+          export const SERVERLESS_URL = '${{ secrets.STG_ZM_SERVERLESS_URL }}';
           EOT
       # Run a single command using the runners shell to install dependencies 
       - name: Install dependencies

--- a/.github/workflows/zimbabwe_staging.yml
+++ b/.github/workflows/zimbabwe_staging.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           cat <<EOT >> ./private/secret.ts
           export const API_KEY = '${{ secrets.IP_FIND_API_KEY }}';
+          export const SERVERLESS_URL = '${{ secrets.STG_ZW_SERVERLESS_URL }}';
           EOT
       # Run a single command using the runners shell to install dependencies 
       - name: Install dependencies

--- a/configurations/pl-staging.ts
+++ b/configurations/pl-staging.ts
@@ -16,7 +16,7 @@ const translations: Translations = {
 };
 
 const preEngagementConfig: PreEngagementConfig = {
-  description: "Thank you for contacting SafeSpot. To chat with a counsellor, please type your name and select the Start Chat button.",
+  description: "Thank you for contacting Telefon Zaufania. To chat with a counsellor, please type your name and select the Start Chat button.",
   fields:
     [
       {


### PR DESCRIPTION
Primary Reviewer: @murilovmachado 

## Description
- Update workflows for staging accounts for CL,ET, HU, JM, MW, RO, PL, UK, ZM, ZW, and Beta accounts to call respective serverless endpoints (urls have been added to actions)
TODO:
  - Ensure that `EndChatMsg` is added in messages.json to respective languages in https://github.com/techmatters/serverless/tree/master/assets/translations and serverless deployed

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes # 1478

### Verification steps
- Check to ensure webchat's end chat button exists and works in CL,ET, HU, JM, MW, RO, PL, UK, ZM, ZW staging accounts after deploy
- Check that End Chat button ends the chat successfully with the 'you ended chat' message