### PR TITLE
Bug fix: End Chat button missing language parameter

### DIFF
--- a/src/components/EndChatButton.tsx
+++ b/src/components/EndChatButton.tsx
@@ -14,14 +14,6 @@ type Props = {
 export default function EndChat({ channelSid, token, language }: Props) {
   const handleEndChat = async () => {
     try {
-      const response: any = await endChat(channelSid, token);
-
-      const { isTaskStageAssigned } = response;
-
-      if (!isTaskStageAssigned) {
-        FlexWebChat.Actions.invokeAction('RestartEngagement');
-      }
-
       await endChat(channelSid, token, language);
     } catch (error) {
       console.log(error);


### PR DESCRIPTION
Primary Reviewer: @acedeywin 
## Description
- Bug fix for end chat button action not getting called. 

### Checklist
- [n/a] Corresponding issue has been opened
- [n/a] New tests added

### Related Issues
Fixes - Resolves merge conflict that is missing language parameter

### Verification steps
- End Chat button works and child receives 'you ended chat' message. 
