### PR TITLE
Bug Fix: Language and defaultLanguage will be stored in redux

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
     "no-alert": "off",
     "import/no-extraneous-dependencies": "off",
     "no-use-before-define": "off",
-    "react/display-name": "off"
+    "react/display-name": "off",
+    "no-shadow": "off"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,6 @@
     "no-alert": "off",
     "import/no-extraneous-dependencies": "off",
     "no-use-before-define": "off",
-    "react/display-name": "off",
-    "no-shadow": "off"
+    "react/display-name": "off"
   }
 }

--- a/configurations/index.ts
+++ b/configurations/index.ts
@@ -56,7 +56,6 @@ type PresetConfig =
 const config = rawConfig as PresetConfig;
 
 type ConfigMap = {
-  // eslint-disable-next-line no-shadow
   [config in PresetConfig]: Configuration;
 };
 

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -18,13 +18,15 @@ const initialLanguage = defaultLanguage;
 
 const getChangeLanguageWebChat = (manager: FlexWebChat.Manager) => (language: string) => {
   const twilioStrings = { ...manager.strings }; // save the originals
+  const setLanguage = (language: string) => (manager.store.getState().flex.config.language = language);
   const setNewStrings = (newStrings: FlexWebChat.Strings) => (manager.strings = { ...manager.strings, ...newStrings });
   const translationErrorMsg = 'Could not translate, using default';
-
   try {
     if (language !== defaultLanguage && translations[language]) {
+      setLanguage(language);
       setNewStrings({ ...twilioStrings, ...translations[defaultLanguage], ...translations[language] });
     } else {
+      setLanguage(defaultLanguage);
       setNewStrings({ ...twilioStrings, ...translations[defaultLanguage] });
     }
   } catch (err) {

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -18,6 +18,7 @@ const initialLanguage = defaultLanguage;
 
 const getChangeLanguageWebChat = (manager: FlexWebChat.Manager) => (language: string) => {
   const twilioStrings = { ...manager.strings }; // save the originals
+  // eslint-disable-next-line no-shadow
   const setLanguage = (language: string) => (manager.store.getState().flex.config.language = language);
   const setNewStrings = (newStrings: FlexWebChat.Strings) => (manager.strings = { ...manager.strings, ...newStrings });
   const translationErrorMsg = 'Could not translate, using default';


### PR DESCRIPTION
## Description
- Language was not being stored, hence defaulting to en-US. Language in redux store is set to change now.
- Eslint config that is logging for `no-shadow` turned off. 

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
- Token is not being authorized in Aselo Dev webchat. This branch is deployed in HU staging to test 