### PR TITLE
CHI-1472: Close chat / quick chat translations

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
     "no-alert": "off",
     "import/no-extraneous-dependencies": "off",
     "no-use-before-define": "off",
-    "react/display-name": "off"
+    "react/display-name": "off",
+    "no-negated-condition": "off"
   }
 }

--- a/src/end-chat/CloseChatButtons.tsx
+++ b/src/end-chat/CloseChatButtons.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import * as FlexWebChat from '@twilio/flex-webchat-ui';
+import { Template } from '@twilio/flex-webchat-ui';
 
 import Exit from './QuickExitButton';
 import End from './EndChatButton';
@@ -18,7 +19,7 @@ const CloseChatButtons = ({ channelSid, token, language }: MapStateToProps) => {
       </StyleWrapper>
       <StyleWrapper margin="3px 2px 10px 10px">
         <StyleText margin="2px 5px 0 3px" color="#606b85">
-          Need to leave quickly?
+          <Template code="QuickExitDescription" />
         </StyleText>
         <Exit channelSid={channelSid} token={token} language={language} />
       </StyleWrapper>

--- a/src/end-chat/EndChatButton.tsx
+++ b/src/end-chat/EndChatButton.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/require-default-props */
 import React from 'react';
+import { Template } from '@twilio/flex-webchat-ui';
 
 import { endChat } from './end-chat-service';
 import { EndButtonBase } from './end-chat-styles';
@@ -18,5 +19,9 @@ export default function EndChat({ channelSid, token, language }: Props) {
       console.log(error);
     }
   };
-  return <EndButtonBase onClick={handleEndChat}>End Chat</EndButtonBase>;
+  return (
+    <EndButtonBase onClick={handleEndChat}>
+      <Template code="EndChatButtonLabel" />
+    </EndButtonBase>
+  );
 }

--- a/src/end-chat/QuickExitButton.tsx
+++ b/src/end-chat/QuickExitButton.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/require-default-props */
 import React from 'react';
 import * as FlexWebChat from '@twilio/flex-webchat-ui';
+import { Template } from '@twilio/flex-webchat-ui';
 
 import { endChat } from './end-chat-service';
 import QuickExitIcon from './QuickExitIcon';
@@ -31,7 +32,9 @@ export default function EndChat({ channelSid, token, language }: Props) {
   return (
     <ExitButtonBase onClick={handleExit}>
       <QuickExitIcon />
-      <span style={{ margin: '-3px 0 0 3px' }}>Quick Exit</span>
+      <span style={{ margin: '-3px 0 0 3px' }}>
+        <Template code="QuickExitButtonLabel" />
+      </span>
     </ExitButtonBase>
   );
 }

--- a/src/language.ts
+++ b/src/language.ts
@@ -1,0 +1,57 @@
+import * as FlexWebChat from '@twilio/flex-webchat-ui';
+
+import { Configuration } from '../configurations/types';
+import standardTranslations from './translations';
+
+/**
+ * Loads the 'standard' translations for a language based on the keys in 'standardTranslations'.
+ * If it is an ISO code (e.g. es-AR) it will first look for a module named after the language code only in our example 'es'
+ * If found it will load these translations, if not, create an empty object. Then it will look for a key named specifically for the culture, 'es-AR' in our example
+ * If it finds one, it will merge the translations into those already loaded from just the language, overwriting any with the same code.
+ * If the supplied language does NOT follow this format, i.e. 'Bemba', it will only look for a module named after the language and return those keys
+ * If none of what it searches for are found, if will just return an empty map ({})
+ * @param language
+ */
+const standardTranslationsForLanguage = (language: string): Record<string, string> => {
+  const [languageOnlyCode] = language.split('-');
+  const languageTranslations = standardTranslations[languageOnlyCode] ?? {};
+  const cultureSpecificTranslations = (languageOnlyCode !== language ? standardTranslations[language] : {}) ?? {};
+  return { ...languageTranslations, ...cultureSpecificTranslations }
+}
+
+export const getChangeLanguageWebChat = (manager: FlexWebChat.Manager, config: Configuration) => {
+  const { defaultLanguage, translations: configTranslations } = config;
+  const setNewLanguage = (language: string) => {
+    const twilioStrings = { ...manager.strings }; // save the originals
+    const defaultLanguageTranslations = standardTranslationsForLanguage(defaultLanguage);
+    const languageTranslations = standardTranslationsForLanguage(language);
+    // eslint-disable-next-line no-shadow
+    const setConfigLanguage = (language: string) => (manager.store.getState().flex.config.language = language);
+    const setNewStrings = (newStrings: FlexWebChat.Strings) =>
+      (manager.strings = { ...manager.strings, ...newStrings });
+    if (language !== defaultLanguage && configTranslations[language]) {
+      setConfigLanguage(language);
+      setNewStrings({
+        ...twilioStrings,
+        ...defaultLanguageTranslations,
+        ...configTranslations[defaultLanguage],
+        ...languageTranslations,
+        ...configTranslations[language],
+      });
+    } else {
+      setConfigLanguage(defaultLanguage);
+      setNewStrings({ ...twilioStrings, ...defaultLanguageTranslations, ...configTranslations[defaultLanguage] });
+    }
+  };
+
+  return (language: string) => {
+    try {
+      setNewLanguage(language);
+    } catch (err) {
+      const translationErrorMsg = 'Could not translate, using default';
+      window.alert(translationErrorMsg);
+      console.error(translationErrorMsg, err);
+      setNewLanguage(defaultLanguage);
+    }
+  };
+};

--- a/src/language.ts
+++ b/src/language.ts
@@ -16,8 +16,8 @@ const standardTranslationsForLanguage = (language: string): Record<string, strin
   const [languageOnlyCode] = language.split('-');
   const languageTranslations = standardTranslations[languageOnlyCode] ?? {};
   const cultureSpecificTranslations = (languageOnlyCode !== language ? standardTranslations[language] : {}) ?? {};
-  return { ...languageTranslations, ...cultureSpecificTranslations }
-}
+  return { ...languageTranslations, ...cultureSpecificTranslations };
+};
 
 export const getChangeLanguageWebChat = (manager: FlexWebChat.Manager, config: Configuration) => {
   const { defaultLanguage, translations: configTranslations } = config;

--- a/src/operating-hours.ts
+++ b/src/operating-hours.ts
@@ -1,6 +1,8 @@
-import { OperatingHoursState } from '../configurations/types';
+import { Manager } from '@twilio/flex-webchat-ui';
 
-export const getOperatingHours = async (): Promise<OperatingHoursState> => {
+import { Configuration, OperatingHoursState } from '../configurations/types';
+
+const getOperatingHours = async (): Promise<OperatingHoursState> => {
   const body = { channel: 'webchat' };
 
   const options = {
@@ -27,4 +29,20 @@ export const getOperatingHours = async (): Promise<OperatingHoursState> => {
   }
 
   return responseJson;
+};
+
+export const displayOperatingHours = async (config: Configuration, manager: Manager) => {
+  // If a helpline has operating hours configuration set, the pre engagement config will show alternative canvas during closed or holiday times/days
+  if (config.checkOpenHours) {
+    try {
+      const operatingState = await getOperatingHours();
+      if (operatingState === 'closed' && config.closedHours) {
+        manager.updateConfig({ preEngagementConfig: config.closedHours });
+      } else if (operatingState === 'holiday' && config.holidayHours) {
+        manager.updateConfig({ preEngagementConfig: config.holidayHours });
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  }
 };

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1,0 +1,6 @@
+// eslint-disable-next-line global-require
+export default {
+  EndChatButtonLabel: 'End Chat',
+  QuickExitButtonLabel: 'Quick Exit',
+  QuickExitDescription: 'Need to leave quickly?',
+} as Record<string, string>;

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line global-require
 export default {
-    EndChatButtonLabel: 'Chat finalizado',
-    QuickExitButtonLabel: 'Salida Rápida',
-    QuickExitDescription: '¿Necesitas irte rápido?',
+  EndChatButtonLabel: 'Chat finalizado',
+  QuickExitButtonLabel: 'Salida Rápida',
+  QuickExitDescription: '¿Necesitas irte rápido?',
 } as Record<string, string>;

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -1,0 +1,6 @@
+// eslint-disable-next-line global-require
+export default {
+    EndChatButtonLabel: 'Chat finalizado',
+    QuickExitButtonLabel: 'Salida Rápida',
+    QuickExitDescription: '¿Necesitas irte rápido?',
+} as Record<string, string>;

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line global-require
 export default {
-  EndChatButtonLabel: 'Chat finalizado',
+  EndChatButtonLabel: 'Finalizar Chat',
   QuickExitButtonLabel: 'Salida Rápida',
   QuickExitDescription: '¿Necesitas irte rápido?',
 } as Record<string, string>;

--- a/src/translations/hu.ts
+++ b/src/translations/hu.ts
@@ -1,0 +1,6 @@
+// eslint-disable-next-line global-require
+export default {
+  EndChatButtonLabel: 'Csevegés befejezése',
+  QuickExitButtonLabel: 'Gyors kilépés',
+  QuickExitDescription: 'Gyorsan el kell menni?',
+} as Record<string, string>;

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -1,0 +1,10 @@
+import en from './en';
+import es from './es';
+import hu from './hu';
+import ru from './ru';
+import ukr from './ukr';
+
+
+export default {
+  en, es, hu, ru, ukr
+} as Record<string, Record<string, string>>;

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -4,7 +4,10 @@ import hu from './hu';
 import ru from './ru';
 import ukr from './ukr';
 
-
 export default {
-  en, es, hu, ru, ukr
+  en,
+  es,
+  hu,
+  ru,
+  ukr,
 } as Record<string, Record<string, string>>;

--- a/src/translations/ru.ts
+++ b/src/translations/ru.ts
@@ -1,0 +1,6 @@
+// eslint-disable-next-line global-require
+export default {
+  EndChatButtonLabel: 'Конец чат',
+  QuickExitButtonLabel: 'Быстрый выход',
+  QuickExitDescription: 'Нужно быстро уйти?',
+} as Record<string, string>;

--- a/src/translations/ukr.ts
+++ b/src/translations/ukr.ts
@@ -1,0 +1,6 @@
+// eslint-disable-next-line global-require
+export default {
+  EndChatButtonLabel: 'Завершити чат',
+  QuickExitButtonLabel: 'Швидкий вихід',
+  QuickExitDescription: 'Потрібно швидко піти?',
+} as Record<string, string>;


### PR DESCRIPTION
Primary Reviewer: @GPaoloni (to review the Spanish translations as well as the code ;-) )

## Description

* Added common translations for languages & cultures so they don't need to be specified in every config
* Added translation files for webchat languages (except local Zambia languages)
* Added translation keys for close chat to UI

We still need local language translations for Zambia if those are required (that part of the UI will be in English if not)

### Checklist
- [X] Corresponding issue has been opened

- [ ] English strings reviewed and copyedited
- [X] Strings are localized
- N/A Verified on mobile
- [X] Verified on desktop
- N/A Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))


### Related Issues
Fixes CHI-1472

### Verification steps

Deploy webchat to an English language site and review the Close chat / Quick exit UI
Deploy webchat to an non-english language site and review the Close chat / Quick exit UI
Review the translations in the PR

