### PR TITLE
CHI-1538 - fix: missed ref to mt-prod

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -43,6 +43,7 @@ function checkCONFIG(config) {
     'zw-staging',
     'pl-staging',
     'mt-staging',
+    'mt-prod',
   ];
   const isConfigSet = typeof config !== 'undefined' && presets.includes(config);
 


### PR DESCRIPTION
## Description
I missed a ref to mt-prod

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
