### PR TITLE
CHI1545 Quick exit and end chat buttons fill the full width of widget 

### DIFF
--- a/src/end-chat/QuickExit.tsx
+++ b/src/end-chat/QuickExit.tsx
@@ -39,7 +39,6 @@ export default function QuickExit({ channelSid, token, language }: Props) {
       <StyledQuickExitButton onClick={handleExit}>
         <QuickExitIcon />
         <QuickExitText>
-          Very Very Very  
           <Template code="QuickExitButtonLabel" />
         </QuickExitText>
       </StyledQuickExitButton>

--- a/src/end-chat/QuickExit.tsx
+++ b/src/end-chat/QuickExit.tsx
@@ -39,6 +39,7 @@ export default function QuickExit({ channelSid, token, language }: Props) {
       <StyledQuickExitButton onClick={handleExit}>
         <QuickExitIcon />
         <QuickExitText>
+          Very Very Very  
           <Template code="QuickExitButtonLabel" />
         </QuickExitText>
       </StyledQuickExitButton>

--- a/src/end-chat/end-chat-styles.tsx
+++ b/src/end-chat/end-chat-styles.tsx
@@ -59,7 +59,7 @@ export const ExitDescText = styled('span')`
 
 export const StyledQuickExitButton = styled('button')`
   display: flex;
-  margin: 3px 8px;
+  margin: 3px 10px 0 0;
   background-color: #fbf2f2;
   color: #d22f2f;
   place-items: center;

--- a/src/end-chat/end-chat-styles.tsx
+++ b/src/end-chat/end-chat-styles.tsx
@@ -1,5 +1,4 @@
 import * as FlexWebChat from '@twilio/flex-webchat-ui';
-import { StyledButton } from '@twilio/flex-webchat-ui';
 
 const { styled } = FlexWebChat;
 
@@ -14,6 +13,7 @@ export const StyledEndButton = styled('button')`
   background-color: #1876d0;
   color: #fff;
   width: 100%;
+  flex-grow: 1;
   height: 29px;
   font-weight: bold;
   border: none;
@@ -67,6 +67,7 @@ export const StyledQuickExitButton = styled('button')`
   justify-content: center;
   font-size: 11px;
   min-width: 50%;
+  flex-grow: 1;
   height: 29px;
   font-weight: bold;
   border: none;


### PR DESCRIPTION
Primary Reviewer: @stephenhand 

## Description
- This PR adds minor change that will help quick exit and end chat buttons to fill the full width of the webchat widget (in mobile and desktop)

### Checklist
- [n/a] Corresponding issue has been opened
- [n/a] New tests added
- [n/a] English strings reviewed and copyedited
- [n/a] Strings are localized
- [x] Verified on mobile
- [x] Verified on desktop
- [n/a] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))

### Related Issues
Fixes # 1545 - missed this in original PR

### Verification steps
-Change `QuickExitButtonLabel` with a longer string. 
-Run app in mobile and desktop views
![Screenshot 2022-12-16 at 11 44 55 AM](https://user-images.githubusercontent.com/102122005/208147542-67185671-4163-42cf-a133-c0d2e073d443.png)
