### PR TITLE
Hide floating button on mobile when chat is open

### DIFF
--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -13,7 +13,6 @@ import { getChangeLanguageWebChat } from './language';
 import { applyMobileOptimization } from './mobile-optimization';
 
 updateZIndex();
-applyMobileOptimization();
 
 const currentConfig = getCurrentConfig();
 const { defaultLanguage, translations } = currentConfig;
@@ -157,6 +156,8 @@ export const initWebchat = async () => {
       <CloseChatButtons />
     </Provider>,
   );
+
+  applyMobileOptimization(manager);
 
   // Render WebChat
   webchat.init();

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -157,8 +157,8 @@ export const initWebchat = async () => {
     </Provider>,
   );
 
-  applyMobileOptimization(manager);
-
   // Render WebChat
   webchat.init();
+
+  applyMobileOptimization(manager);
 };

--- a/src/mobile-optimization/full-screen.ts
+++ b/src/mobile-optimization/full-screen.ts
@@ -1,6 +1,8 @@
 import { injectGlobal } from 'react-emotion';
 
-export function fullScreenChat() {
+import { WIDGET_EXPANDED_CLASS } from './widget-expanded-listener';
+
+export function makeMobileFullScreen() {
   return injectGlobal`
     /* 
       This media query matches phones/tablets,
@@ -12,6 +14,11 @@ export function fullScreenChat() {
         left: 0;
         min-height: 100%;
         min-width: 100%;
+      }
+
+      /* Hides the floating button when expanded */
+      button.${WIDGET_EXPANDED_CLASS} {
+        display: none;
       }
     }
   `;

--- a/src/mobile-optimization/full-screen.ts
+++ b/src/mobile-optimization/full-screen.ts
@@ -20,6 +20,16 @@ export function makeMobileFullScreen() {
       button.${WIDGET_EXPANDED_CLASS} {
         display: none;
       }
+
+      /*
+        On mobile, after clicking on the send button, it keeps the button
+        in :hover state, which turns the button grey. Since we could not get
+        rid of :hover state programatically, we're overriding :hover color
+        to #1976D2, to get rid of the grey misleading color
+      */
+      button.Twilio-MessageInput-SendButton:hover {
+        background: #1976D2;
+      }
     }
   `;
 }

--- a/src/mobile-optimization/index.ts
+++ b/src/mobile-optimization/index.ts
@@ -5,7 +5,10 @@
  * is not desired, you can disable it by setting 'disable-mobile-optimization' attribute:
  * <script disable-mobile-optimization src='path/to/aselo.js'></script>
  */
-import { fullScreenChat } from './full-screen';
+import * as FlexWebChat from '@twilio/flex-webchat-ui';
+
+import { makeMobileFullScreen } from './full-screen';
+import { addWidgetExpandedListener } from './widget-expanded-listener';
 import { updateViewport } from './viewport';
 
 function shouldDisableMobileOptimization() {
@@ -13,11 +16,12 @@ function shouldDisableMobileOptimization() {
   return ['', true, 'true'].some((value) => value === disableMobileOptimizationAttribute);
 }
 
-export function applyMobileOptimization() {
+export function applyMobileOptimization(manager: FlexWebChat.Manager) {
   if (shouldDisableMobileOptimization()) {
     return;
   }
 
-  fullScreenChat();
+  makeMobileFullScreen();
+  addWidgetExpandedListener(manager);
   updateViewport();
 }

--- a/src/mobile-optimization/widget-expanded-listener.ts
+++ b/src/mobile-optimization/widget-expanded-listener.ts
@@ -1,0 +1,24 @@
+import * as FlexWebChat from '@twilio/flex-webchat-ui';
+
+export const WIDGET_EXPANDED_CLASS = 'AseloWidget-Expanded';
+
+/**
+ * This listener adds/removes '.AseloWidget-Expanded' class to the widget's
+ * floating button. On a mobile device, this class will hide the floating button.
+ */
+export function addWidgetExpandedListener(manager: FlexWebChat.Manager) {
+  FlexWebChat.Actions.addListener('afterToggleChatVisibility', () => {
+    const entryPointButton = document.querySelector<HTMLButtonElement>('button.Twilio-EntryPoint');
+    if (!entryPointButton) {
+      return;
+    }
+
+    const { isEntryPointExpanded } = manager.store.getState().flex.session;
+
+    if (isEntryPointExpanded) {
+      entryPointButton.classList.add(WIDGET_EXPANDED_CLASS);
+    } else {
+      entryPointButton.classList.remove(WIDGET_EXPANDED_CLASS);
+    }
+  });
+}

--- a/src/mobile-optimization/widget-expanded-listener.ts
+++ b/src/mobile-optimization/widget-expanded-listener.ts
@@ -8,7 +8,6 @@ export const WIDGET_EXPANDED_CLASS = 'AseloWidget-Expanded';
  */
 function addOrRemoveWidgetExpandedClass(manager: FlexWebChat.Manager) {
   const entryPointButton = document.querySelector<HTMLButtonElement>('button.Twilio-EntryPoint');
-  console.log({ manager, entryPointButton });
   if (!entryPointButton) {
     return;
   }

--- a/src/mobile-optimization/widget-expanded-listener.ts
+++ b/src/mobile-optimization/widget-expanded-listener.ts
@@ -3,22 +3,36 @@ import * as FlexWebChat from '@twilio/flex-webchat-ui';
 export const WIDGET_EXPANDED_CLASS = 'AseloWidget-Expanded';
 
 /**
- * This listener adds/removes '.AseloWidget-Expanded' class to the widget's
+ * This function adds/removes '.AseloWidget-Expanded' class to the widget's
  * floating button. On a mobile device, this class will hide the floating button.
  */
+function addOrRemoveWidgetExpandedClass(manager: FlexWebChat.Manager) {
+  const entryPointButton = document.querySelector<HTMLButtonElement>('button.Twilio-EntryPoint');
+  console.log({ manager, entryPointButton });
+  if (!entryPointButton) {
+    return;
+  }
+
+  const { isEntryPointExpanded } = manager.store.getState().flex.session;
+
+  if (isEntryPointExpanded) {
+    entryPointButton.classList.add(WIDGET_EXPANDED_CLASS);
+  } else {
+    entryPointButton.classList.remove(WIDGET_EXPANDED_CLASS);
+  }
+}
+
 export function addWidgetExpandedListener(manager: FlexWebChat.Manager) {
-  FlexWebChat.Actions.addListener('afterToggleChatVisibility', () => {
-    const entryPointButton = document.querySelector<HTMLButtonElement>('button.Twilio-EntryPoint');
-    if (!entryPointButton) {
-      return;
-    }
+  /**
+   * Calls addOrRemoveWidgetExpandedClass a first time to handle the scenario
+   * where the chat is initially expanded
+   */
+  addOrRemoveWidgetExpandedClass(manager);
 
-    const { isEntryPointExpanded } = manager.store.getState().flex.session;
-
-    if (isEntryPointExpanded) {
-      entryPointButton.classList.add(WIDGET_EXPANDED_CLASS);
-    } else {
-      entryPointButton.classList.remove(WIDGET_EXPANDED_CLASS);
-    }
-  });
+  /**
+   * Calls addOrRemoveWidgetExpandedClass everytime the user toggles
+   * the chat's visibility. This will make the button visible again
+   * in case the chat is collapsed.
+   */
+  FlexWebChat.Actions.addListener('afterToggleChatVisibility', () => addOrRemoveWidgetExpandedClass(manager));
 }


### PR DESCRIPTION
Primary reviewer: @mmythily @GPaoloni 

## Description
This PR removes the floating button when a chat is open at full screen on a mobile device.

Old (with floating button):
![image](https://user-images.githubusercontent.com/1504544/208467256-ec9f1f35-8fae-4b3d-a834-47587ee474ee.png)

New:
![image](https://user-images.githubusercontent.com/1504544/208467383-5426dfb2-9af0-40cd-a694-8e4e9e164f99.png)


### Checklist
- [x] Verified on mobile
- [x] Verified on desktop

### Related Issues
Fixes https://tech-matters.atlassian.net/browse/CHI-1355

### Verification steps
Open the chat on a mobile device and see that the floating button is not visible.
It should still be visible for desktop.
