### PR TITLE
CHI-1610: Fix end chat on chatbot / pre-engagement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1648,6 +1648,17 @@
           "requires": {
             "react-is": "^16.7.0"
           }
+        },
+        "redux": {
+          "version": "3.7.2",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
+          "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+          "requires": {
+            "lodash": "^4.2.1",
+            "lodash-es": "^4.2.1",
+            "loose-envify": "^1.1.0",
+            "symbol-observable": "^1.0.3"
+          }
         }
       }
     },
@@ -1675,6 +1686,19 @@
         "redux-promise-middleware": "4.2.1",
         "semver": "~5.7.0",
         "twilio-chat": "~3.4.0"
+      },
+      "dependencies": {
+        "redux": {
+          "version": "3.7.2",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
+          "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+          "requires": {
+            "lodash": "^4.2.1",
+            "lodash-es": "^4.2.1",
+            "loose-envify": "^1.1.0",
+            "symbol-observable": "^1.0.3"
+          }
+        }
       }
     },
     "@types/eslint": {
@@ -7218,14 +7242,11 @@
       }
     },
     "redux": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
       "requires": {
-        "lodash": "^4.2.1",
-        "lodash-es": "^4.2.1",
-        "loose-envify": "^1.1.0",
-        "symbol-observable": "^1.0.3"
+        "@babel/runtime": "^7.9.2"
       }
     },
     "redux-logger": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "webpack-utf8-bom": "^1.3.0"
   },
   "dependencies": {
-    "@twilio/flex-webchat-ui": "^2.9.1"
+    "@twilio/flex-webchat-ui": "^2.9.1",
+    "redux": "^4.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,5 +58,8 @@
   "dependencies": {
     "@twilio/flex-webchat-ui": "^2.9.1",
     "redux": "^4.2.0"
+  },
+  "prettier": {
+    "endOfLine": "auto"
   }
 }

--- a/src/aselo-webchat-state.ts
+++ b/src/aselo-webchat-state.ts
@@ -1,23 +1,20 @@
-
 import { combineReducers } from 'redux';
 import { AppState, WebchatReducer } from '@twilio/flex-webchat-ui';
+
 import { taskReducer, TaskState } from './task';
 
-export const aseloWebchat = 'aselo-webchat-state'
-
-
 export type AseloWebchatState = {
-  flex: AppState
-  task: TaskState
-}
+  flex: AppState;
+  task: TaskState;
+};
 
 const reducers = {
   flex: (state: AppState | undefined, action: any) => WebchatReducer(state as AppState, action),
-  task: taskReducer
-} as const
+  task: taskReducer,
+} as const;
 
 const combinedReducer = combineReducers<AseloWebchatState>(reducers);
 
 export const aseloReducer = (state: AseloWebchatState | undefined, action: any) => {
   return combinedReducer(state, action);
-}
+};

--- a/src/aselo-webchat-state.ts
+++ b/src/aselo-webchat-state.ts
@@ -1,0 +1,23 @@
+
+import { combineReducers } from 'redux';
+import { AppState, WebchatReducer } from '@twilio/flex-webchat-ui';
+import { taskReducer, TaskState } from './task';
+
+export const aseloWebchat = 'aselo-webchat-state'
+
+
+export type AseloWebchatState = {
+  flex: AppState
+  task: TaskState
+}
+
+const reducers = {
+  flex: (state: AppState | undefined, action: any) => WebchatReducer(state as AppState, action),
+  task: taskReducer
+} as const
+
+const combinedReducer = combineReducers<AseloWebchatState>(reducers);
+
+export const aseloReducer = (state: AseloWebchatState | undefined, action: any) => {
+  return combinedReducer(state, action);
+}

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -11,6 +11,10 @@ import blockedIps from './blockedIps.json';
 import CloseChatButtons from './end-chat/CloseChatButtons';
 import { getChangeLanguageWebChat } from './language';
 import { applyMobileOptimization } from './mobile-optimization';
+import { aseloReducer } from './aselo-webchat-state';
+import { FlexState } from '@twilio/flex-webchat-ui/src/Store';
+import { Reducer } from 'redux';
+import { subscribeToChannel } from './task';
 
 updateZIndex();
 applyMobileOptimization();
@@ -19,14 +23,11 @@ const currentConfig = getCurrentConfig();
 const { defaultLanguage, translations } = currentConfig;
 const initialLanguage = defaultLanguage;
 
-type ChannelAndManagerAndIpFn = (channel: Channel, manager: FlexWebChat.Manager, ip?: string) => void;
-
-const doWithChannel = (callback: ChannelAndManagerAndIpFn) => (manager: FlexWebChat.Manager, ip?: string) => {
+const chatChannel = async (manager: FlexWebChat.Manager): Promise<Channel> => {
   const { channelSid } = manager.store.getState().flex.session;
-  manager.chatClient.getChannelBySid(channelSid).then((channel) => {
-    callback(channel, manager, ip);
-  });
+  return manager.chatClient.getChannelBySid(channelSid);
 };
+
 
 const unlockInput = (manager: FlexWebChat.Manager) => {
   const { user } = manager.chatClient;
@@ -55,18 +56,18 @@ const setListenerToUnlockInput = async (channel: Channel, manager: FlexWebChat.M
   });
 };
 
-const setChannelOnCreateWebChat = doWithChannel(setListenerToUnlockInput);
+const setChannelOnCreateWebChat = async (channel: Channel, manager: FlexWebChat.Manager) => {
 
-const setChannelAfterStartEngagement = doWithChannel(
-  (channel: Channel, manager: FlexWebChat.Manager, ip: string = '') => {
-    setListenerToUnlockInput(channel, manager);
+  setListenerToUnlockInput(channel, manager);
+}
 
-    // Generate task by sending empty message (hidden from the UI above)
-    const message = `${translations[initialLanguage].AutoFirstMessage} ${ip}`;
-    channel.sendMessage(message);
-  },
-);
+const setChannelAfterStartEngagement = async (channel: Channel, manager: FlexWebChat.Manager, ip: string = '') => {
+  setListenerToUnlockInput(channel, manager);
 
+  // Generate task by sending empty message (hidden from the UI above)
+  const message = `${translations[initialLanguage].AutoFirstMessage} ${ip}`;
+  channel.sendMessage(message);
+};
 export const initWebchat = async () => {
   let ip: string | undefined;
 
@@ -105,15 +106,20 @@ export const initWebchat = async () => {
 
   const webchat = await FlexWebChat.createWebChat(appConfig);
   const { manager } = webchat;
+  manager.store.replaceReducer(aseloReducer as Reducer<FlexState>)
 
-  displayOperatingHours(currentConfig, manager);
+  await displayOperatingHours(currentConfig, manager);
 
   const changeLanguageWebChat = getChangeLanguageWebChat(manager, currentConfig);
 
   changeLanguageWebChat(initialLanguage);
 
   // If caller is waiting for a counselor to connect, disable input (default language)
-  if (manager.chatClient) setChannelOnCreateWebChat(manager);
+  if (manager.chatClient) {
+    const channel = await chatChannel(manager);
+    await setChannelOnCreateWebChat(channel, manager);
+    await subscribeToChannel(manager, channel);
+  }
 
   // Disable greeting message as chatbot already includes one
   FlexWebChat.MessagingCanvas.defaultProps.predefinedMessage = undefined;
@@ -142,12 +148,16 @@ export const initWebchat = async () => {
     // Here we collect caller language (from preEngagement select) and change UI language
     changeLanguageWebChat(language);
 
-    setChannelAfterStartEngagement(manager, ip);
+    const channel = await chatChannel(manager);
+    await setChannelAfterStartEngagement(channel, manager, ip);
+    await subscribeToChannel(manager, channel);
+
   });
 
   FlexWebChat.Actions.addListener('afterRestartEngagement', (payload) => {
     if (payload.exit) {
       setTimeout(() => window.open('https://google.com', '_self'), 1000);
+    } else {
     }
   });
 

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import * as FlexWebChat from '@twilio/flex-webchat-ui';
 import { Channel } from 'twilio-chat/lib/channel';
 import { Provider } from 'react-redux';
+import { FlexState } from '@twilio/flex-webchat-ui/src/Store';
+import { Reducer } from 'redux';
 
 import { getUserIp } from './ip-tracker';
 import { displayOperatingHours } from './operating-hours';
@@ -12,8 +14,6 @@ import CloseChatButtons from './end-chat/CloseChatButtons';
 import { getChangeLanguageWebChat } from './language';
 import { applyMobileOptimization } from './mobile-optimization';
 import { aseloReducer } from './aselo-webchat-state';
-import { FlexState } from '@twilio/flex-webchat-ui/src/Store';
-import { Reducer } from 'redux';
 import { subscribeToChannel } from './task';
 
 updateZIndex();
@@ -27,7 +27,6 @@ const chatChannel = async (manager: FlexWebChat.Manager): Promise<Channel> => {
   const { channelSid } = manager.store.getState().flex.session;
   return manager.chatClient.getChannelBySid(channelSid);
 };
-
 
 const unlockInput = (manager: FlexWebChat.Manager) => {
   const { user } = manager.chatClient;
@@ -57,9 +56,8 @@ const setListenerToUnlockInput = async (channel: Channel, manager: FlexWebChat.M
 };
 
 const setChannelOnCreateWebChat = async (channel: Channel, manager: FlexWebChat.Manager) => {
-
   setListenerToUnlockInput(channel, manager);
-}
+};
 
 const setChannelAfterStartEngagement = async (channel: Channel, manager: FlexWebChat.Manager, ip: string = '') => {
   setListenerToUnlockInput(channel, manager);
@@ -106,7 +104,7 @@ export const initWebchat = async () => {
 
   const webchat = await FlexWebChat.createWebChat(appConfig);
   const { manager } = webchat;
-  manager.store.replaceReducer(aseloReducer as Reducer<FlexState>)
+  manager.store.replaceReducer(aseloReducer as Reducer<FlexState>);
 
   await displayOperatingHours(currentConfig, manager);
 
@@ -151,7 +149,6 @@ export const initWebchat = async () => {
     const channel = await chatChannel(manager);
     await setChannelAfterStartEngagement(channel, manager, ip);
     await subscribeToChannel(manager, channel);
-
   });
 
   FlexWebChat.Actions.addListener('afterRestartEngagement', (payload) => {

--- a/src/end-chat/CloseChatButtons.tsx
+++ b/src/end-chat/CloseChatButtons.tsx
@@ -6,14 +6,18 @@ import Exit from './QuickExit';
 import End from './EndChat';
 import { AseloWebchatState } from '../aselo-webchat-state';
 
-
 const CloseChatButtons = ({ channelSid, token, language, taskSid }: MapStateToProps) => {
   if (!channelSid || !token) {
     return null;
   }
   return (
     <>
-      <End channelSid={channelSid} token={token} language={language} action={taskSid ? 'finishTask' : 'restartEngagement'} />
+      <End
+        channelSid={channelSid}
+        token={token}
+        language={language}
+        action={taskSid ? 'finishTask' : 'restartEngagement'}
+      />
       <Exit channelSid={channelSid} token={token} language={language} finishTask={Boolean(taskSid)} />
     </>
   );
@@ -22,14 +26,13 @@ const CloseChatButtons = ({ channelSid, token, language, taskSid }: MapStateToPr
 type MapStateToProps = ReturnType<typeof mapStateToProps>;
 
 const mapStateToProps = (state: AseloWebchatState) => {
-  const { channelSid, tokenPayload, engagementStage } = state?.flex?.session ?? {};
+  const { channelSid, tokenPayload } = state?.flex?.session ?? {};
   return {
     taskSid: state?.task?.currentSid,
     channelSid,
     token: tokenPayload?.token,
     language: state?.flex?.config?.language,
-    engagementStage
-  }
+  };
 };
 
 export default connect(mapStateToProps)(CloseChatButtons);

--- a/src/end-chat/CloseChatButtons.tsx
+++ b/src/end-chat/CloseChatButtons.tsx
@@ -1,37 +1,35 @@
 /* eslint-disable react/require-default-props */
 import * as React from 'react';
 import { connect } from 'react-redux';
-import * as FlexWebChat from '@twilio/flex-webchat-ui';
 
 import Exit from './QuickExit';
 import End from './EndChat';
+import { AseloWebchatState } from '../aselo-webchat-state';
 
-const CloseChatButtons = ({ channelSid, token, language }: MapStateToProps) => {
+
+const CloseChatButtons = ({ channelSid, token, language, taskSid }: MapStateToProps) => {
   if (!channelSid || !token) {
     return null;
   }
   return (
     <>
-      <End channelSid={channelSid} token={token} language={language} />
-      <Exit channelSid={channelSid} token={token} language={language} />
+      <End channelSid={channelSid} token={token} language={language} action={taskSid ? 'finishTask' : 'restartEngagement'} />
+      <Exit channelSid={channelSid} token={token} language={language} finishTask={Boolean(taskSid)} />
     </>
   );
 };
 
-type MapStateToProps = {
-  channelSid?: string;
-  token?: string;
-  language?: string;
-};
+type MapStateToProps = ReturnType<typeof mapStateToProps>;
 
-type FlexState = {
-  flex: FlexWebChat.AppState;
+const mapStateToProps = (state: AseloWebchatState) => {
+  const { channelSid, tokenPayload, engagementStage } = state?.flex?.session ?? {};
+  return {
+    taskSid: state?.task?.currentSid,
+    channelSid,
+    token: tokenPayload?.token,
+    language: state?.flex?.config?.language,
+    engagementStage
+  }
 };
-
-const mapStateToProps = (state: FlexState) => ({
-  channelSid: state?.flex?.session?.channelSid,
-  token: state?.flex?.session?.tokenPayload?.token,
-  language: state?.flex?.config?.language,
-});
 
 export default connect(mapStateToProps)(CloseChatButtons);

--- a/src/end-chat/EndChat.tsx
+++ b/src/end-chat/EndChat.tsx
@@ -1,16 +1,16 @@
 /* eslint-disable react/require-default-props */
 import React from 'react';
 import { Template } from '@twilio/flex-webchat-ui';
+import * as FlexWebChat from '@twilio/flex-webchat-ui';
 
 import { finishChatTask } from './end-chat-service';
 import { EndChatWrapper, StyledEndButton } from './end-chat-styles';
-import * as FlexWebChat from '@twilio/flex-webchat-ui';
 
 type Props = {
   channelSid: string;
   token: string;
   language?: string;
-  action: 'finishTask' | 'restartEngagement'
+  action: 'finishTask' | 'restartEngagement';
 };
 
 export default function EndChat({ channelSid, token, language, action }: Props) {
@@ -25,8 +25,8 @@ export default function EndChat({ channelSid, token, language, action }: Props) 
         }
         return;
       case 'restartEngagement':
-        await FlexWebChat.Actions.invokeAction('RestartEngagement', { exit: false })
-        return;
+      default:
+        await FlexWebChat.Actions.invokeAction('RestartEngagement', { exit: false });
     }
   };
   return (

--- a/src/end-chat/EndChat.tsx
+++ b/src/end-chat/EndChat.tsx
@@ -2,22 +2,31 @@
 import React from 'react';
 import { Template } from '@twilio/flex-webchat-ui';
 
-import { endChat } from './end-chat-service';
+import { finishChatTask } from './end-chat-service';
 import { EndChatWrapper, StyledEndButton } from './end-chat-styles';
+import * as FlexWebChat from '@twilio/flex-webchat-ui';
 
 type Props = {
   channelSid: string;
   token: string;
   language?: string;
+  action: 'finishTask' | 'restartEngagement'
 };
 
-export default function EndChat({ channelSid, token, language }: Props) {
+export default function EndChat({ channelSid, token, language, action }: Props) {
   // Serverless call to end chat
   const handleEndChat = async () => {
-    try {
-      await endChat(channelSid, token, language);
-    } catch (error) {
-      console.log(error);
+    switch (action) {
+      case 'finishTask':
+        try {
+          await finishChatTask(channelSid, token, language);
+        } catch (error) {
+          console.log(error);
+        }
+        return;
+      case 'restartEngagement':
+        await FlexWebChat.Actions.invokeAction('RestartEngagement', { exit: false })
+        return;
     }
   };
   return (

--- a/src/end-chat/QuickExit.tsx
+++ b/src/end-chat/QuickExit.tsx
@@ -15,9 +15,8 @@ type Props = {
 };
 
 export default function QuickExit({ channelSid, token, language, finishTask }: Props) {
-
   const handleExit = async () => {
-    const actions: Promise<unknown>[] = []
+    const actions: Promise<unknown>[] = [];
     if (finishTask) {
       // Only if we started a task
       try {

--- a/src/end-chat/end-chat-service.ts
+++ b/src/end-chat/end-chat-service.ts
@@ -2,7 +2,7 @@ type Token = string;
 type ChannelSid = string;
 type Language = string;
 
-export const endChat = async (channelSid: ChannelSid, token: Token, language?: Language): Promise<Token> => {
+export const finishChatTask = async (channelSid: ChannelSid, token: Token, language?: Language): Promise<Token> => {
   const body = { channelSid, Token: token, language };
 
   const options = {

--- a/src/task.ts
+++ b/src/task.ts
@@ -1,0 +1,42 @@
+import { Manager } from '@twilio/flex-webchat-ui';
+import { Channel } from 'twilio-chat/lib/channel';
+
+
+export type TaskState = {
+  currentSid?: string
+}
+
+const initialState: TaskState = {}
+
+const SET_CURRENT_TASK = 'setCurrentTask'
+
+type SetCurrentTaskAction = {
+  type: typeof SET_CURRENT_TASK
+  newSid: string | undefined
+}
+
+export const setCurrentTaskFromChannel = (channel: Channel): SetCurrentTaskAction => {
+  const attributes: { taskSid: string} = channel.attributes as any;
+  console.log("Channel State Changed", attributes, channel);
+  return ({ type: SET_CURRENT_TASK, newSid: attributes?.taskSid });
+}
+
+export const taskReducer = (state: TaskState = initialState, action: SetCurrentTaskAction) => {
+  switch (action.type) {
+    case SET_CURRENT_TASK:
+      return { ...state, currentSid: action.newSid };
+    default:
+      return state;
+  }
+}
+
+export const subscribeToChannel = (async (manager: Manager, channel: Channel) => {
+  channel.addListener('updated', () => {
+    manager.store.dispatch(setCurrentTaskFromChannel(channel));
+  });
+  channel.addListener('removed', () => {
+
+    console.log("REMOVED FROM CHANNEL!");
+  })
+  manager.store.dispatch(setCurrentTaskFromChannel(channel));
+});

--- a/src/task.ts
+++ b/src/task.ts
@@ -1,42 +1,38 @@
 import { Manager } from '@twilio/flex-webchat-ui';
 import { Channel } from 'twilio-chat/lib/channel';
 
-
 export type TaskState = {
-  currentSid?: string
-}
+  currentSid?: string;
+};
 
-const initialState: TaskState = {}
+const initialState: TaskState = {};
 
-const SET_CURRENT_TASK = 'setCurrentTask'
+const SET_CURRENT_TASK = 'setCurrentTask';
 
 type SetCurrentTaskAction = {
-  type: typeof SET_CURRENT_TASK
-  newSid: string | undefined
-}
+  type: typeof SET_CURRENT_TASK;
+  newSid: string | undefined;
+};
 
-export const setCurrentTaskFromChannel = (channel: Channel): SetCurrentTaskAction => {
-  const attributes: { taskSid: string} = channel.attributes as any;
-  console.log("Channel State Changed", attributes, channel);
-  return ({ type: SET_CURRENT_TASK, newSid: attributes?.taskSid });
-}
+const setCurrentTaskFromChannel = (channel: Channel): SetCurrentTaskAction => {
+  const attributes: { taskSid: string } = channel.attributes as any;
+  console.log('Channel State Changed', attributes, channel);
+  return { type: SET_CURRENT_TASK, newSid: attributes?.taskSid };
+};
 
 export const taskReducer = (state: TaskState = initialState, action: SetCurrentTaskAction) => {
-  switch (action.type) {
-    case SET_CURRENT_TASK:
-      return { ...state, currentSid: action.newSid };
-    default:
-      return state;
+  if (action.type === SET_CURRENT_TASK) {
+    return { ...state, currentSid: action.newSid };
   }
-}
+  return state;
+};
 
-export const subscribeToChannel = (async (manager: Manager, channel: Channel) => {
+export const subscribeToChannel = async (manager: Manager, channel: Channel) => {
   channel.addListener('updated', () => {
     manager.store.dispatch(setCurrentTaskFromChannel(channel));
   });
   channel.addListener('removed', () => {
-
-    console.log("REMOVED FROM CHANNEL!");
-  })
+    console.log('REMOVED FROM CHANNEL!');
+  });
   manager.store.dispatch(setCurrentTaskFromChannel(channel));
-});
+};

--- a/src/task.ts
+++ b/src/task.ts
@@ -16,7 +16,6 @@ type SetCurrentTaskAction = {
 
 const setCurrentTaskFromChannel = (channel: Channel): SetCurrentTaskAction => {
   const attributes: { taskSid: string } = channel.attributes as any;
-  console.log('Channel State Changed', attributes, channel);
   return { type: SET_CURRENT_TASK, newSid: attributes?.taskSid };
 };
 
@@ -30,9 +29,6 @@ export const taskReducer = (state: TaskState = initialState, action: SetCurrentT
 export const subscribeToChannel = async (manager: Manager, channel: Channel) => {
   channel.addListener('updated', () => {
     manager.store.dispatch(setCurrentTaskFromChannel(channel));
-  });
-  channel.addListener('removed', () => {
-    console.log('REMOVED FROM CHANNEL!');
   });
   manager.store.dispatch(setCurrentTaskFromChannel(channel));
 };


### PR DESCRIPTION
Primary Reviewer: @murilovmachado 

## Description

* Added aselo redux state. 
* Monitor channel for taskSid attribute and add it to the redux state
* Change exit logic based on whether a task is present on the chat channel. If no task is present, just restart the engagement
* Also prevented quick exit from attempting to finish the task before there is one on the channel
* Put the 2 'Quick Exit' tasks in a `PRomise.all` for a quicker exit

### Checklist
- [X] Corresponding issue has been opened
- N/A New tests added


### Related Issues
Fixes CHI-1610

### Verification steps

* Verify quick exit clears chat & redirects to google in every engagement stage
* Verify end chat ends current chat session in chatbot & pre-engagement stages
