### PR TITLE
Implement email as an alternative contact identifier (in addition to ip address)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,7 @@
     "import/no-extraneous-dependencies": "off",
     "no-use-before-define": "off",
     "react/display-name": "off",
-    "no-negated-condition": "off"
+    "no-negated-condition": "off",
+    "no-warning-comments": "off"
   }
 }

--- a/configurations/beta.ts
+++ b/configurations/beta.ts
@@ -1,9 +1,11 @@
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage } from './types';
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from './types';
 
 const accountSid = 'AC6b99858a6faf7af1b572c83988b50eb1';
 const flexFlowSid = 'FO57c22d5dfc7a18dcada507aa70ca0cb3';
 const defaultLanguage = 'en-US';
 const captureIp = true;
+const contactType: ContactType = 'ip';
+
 
 const translations: Translations = {
   'ar': {
@@ -177,4 +179,5 @@ export const config: Configuration = {
   preEngagementConfig,
   mapHelplineLanguage,
   captureIp,
+  contactType
 };

--- a/configurations/ca-staging.ts
+++ b/configurations/ca-staging.ts
@@ -3,6 +3,7 @@ import {
     Translations,
     Configuration,
     MapHelplineLanguage,
+    ContactType
   } from './types';
   
   const accountSid = 'ACeb335f4685aa874fddf00cdd7c2946bd';
@@ -10,6 +11,8 @@ import {
   const defaultLanguage = 'en-US';
   const captureIp = false;
   const checkOpenHours = true;
+const contactType: ContactType = 'ip';
+
   
   const translations: Translations = {
     'en-US': {
@@ -681,5 +684,6 @@ import {
     mapHelplineLanguage,
     memberDisplayOptions,
     captureIp,
+    contactType
   };
   

--- a/configurations/cl-staging.ts
+++ b/configurations/cl-staging.ts
@@ -1,9 +1,10 @@
-import {PreEngagementConfig,Translations,Configuration,MapHelplineLanguage} from './types'
+import {PreEngagementConfig,Translations,Configuration,MapHelplineLanguage,ContactType} from './types'
 
 const accountSid = 'AC6ca34b61e7bf2d7cf8b8ca24e7efe65f';
 const flexFlowSid = 'FO11691bbc019d7c4c4b9229fedc77961d';
 const defaultLanguage = 'es-CL';
 const captureIp = true;
+const contactType: ContactType = 'ip';
 
 const preEngagementConfig: PreEngagementConfig = {
   description: "Bievenido a Línea Libre",
@@ -132,4 +133,5 @@ export const config: Configuration = {
   mapHelplineLanguage,
   memberDisplayOptions,
   captureIp,
+  contactType,
 };

--- a/configurations/co-staging.ts
+++ b/configurations/co-staging.ts
@@ -1,10 +1,12 @@
-import {PreEngagementConfig,Translations,Configuration,MapHelplineLanguage} from './types'
+import {PreEngagementConfig,Translations,Configuration,MapHelplineLanguage,ContactType} from './types'
 
 const accountSid = 'AC76b8bd2798b01b067a1be7f17d36c894';
 const flexFlowSid = 'FOd992a9ef451a263c83c8e556b5393887';
 const defaultLanguage = 'es-CO';
 const captureIp = true;
 const checkOpenHours = true;
+const contactType: ContactType = 'ip';
+
 
 const preEngagementConfig: PreEngagementConfig = {
   description: "Comencemos",
@@ -121,4 +123,5 @@ export const config: Configuration = {
   mapHelplineLanguage,
   memberDisplayOptions,
   captureIp,
+  contactType
 };

--- a/configurations/dev.ts
+++ b/configurations/dev.ts
@@ -54,7 +54,7 @@ const preEngagementConfig: PreEngagementConfig = {
         type: "InputItem",
         attributes:
         {
-          name: "email",
+          name: "contactIdentifier",
           type: "email",
           required: true,
           readOnly: false

--- a/configurations/dev.ts
+++ b/configurations/dev.ts
@@ -55,7 +55,7 @@ const preEngagementConfig: PreEngagementConfig = {
         attributes:
         {
           name: "email",
-          type: "text",
+          type: "email",
           required: true,
           readOnly: false
         },

--- a/configurations/dev.ts
+++ b/configurations/dev.ts
@@ -1,4 +1,4 @@
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage } from './types';
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from './types';
 
 const accountSid = 'ACd8a2e89748318adf6ddff7df6948deaf';
 const flexFlowSid = 'FO8c2d9c388e7feba8b08d06a4bc3f69d1';
@@ -6,12 +6,14 @@ const defaultLanguage = 'en-US';
 const captureIp = true;
 const checkOpenHours = true;
 
+const contactType: ContactType = 'email';
+
 const translations: Translations = {
   'en-US': {
     WelcomeMessage: "Welcome to Aselo!",
     MessageCanvasTrayContent:"",
     MessageInputDisabledReasonHold: "Please hold for a counselor.",
-    AutoFirstMessage: "Incoming webchat contact from",
+    AutoFirstMessage: "Incoming webchat csontact from",
   },
   'es': {
     EntryPointTagline: "Chatea con nosotros",
@@ -47,6 +49,17 @@ const preEngagementConfig: PreEngagementConfig = {
   description: "Let's get started",
   fields:
     [
+      {
+        label: "What is your email?",
+        type: "InputItem",
+        attributes:
+        {
+          name: "email",
+          type: "text",
+          required: true,
+          readOnly: false
+        },
+      },
       {
         label: "What is your helpline?",
         type: "SelectItem",
@@ -125,4 +138,5 @@ export const config: Configuration = {
   checkOpenHours,
   mapHelplineLanguage,
   captureIp,
+  contactType
 };

--- a/configurations/dev.ts
+++ b/configurations/dev.ts
@@ -13,7 +13,7 @@ const translations: Translations = {
     WelcomeMessage: "Welcome to Aselo!",
     MessageCanvasTrayContent:"",
     MessageInputDisabledReasonHold: "Please hold for a counselor.",
-    AutoFirstMessage: "Incoming webchat csontact from",
+    AutoFirstMessage: "Incoming webchat contact from",
   },
   'es': {
     EntryPointTagline: "Chatea con nosotros",

--- a/configurations/e2e-dev.ts
+++ b/configurations/e2e-dev.ts
@@ -1,9 +1,11 @@
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage } from './types';
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from './types';
 
 const accountSid = 'AC6a65d4fbbc731e64e1c94e9806675c3b';
 const flexFlowSid = 'FOfce25fd1dff726dcdae2899de86de6c5';
 const defaultLanguage = 'en-US';
 const captureIp = true;
+const contactType: ContactType = 'ip';
+
 
 const translations: Translations = {
   'en-US': {
@@ -60,4 +62,5 @@ export const config: Configuration = {
   mapHelplineLanguage,
   memberDisplayOptions,
   captureIp,
+  contactType
 };

--- a/configurations/et-staging.ts
+++ b/configurations/et-staging.ts
@@ -1,9 +1,10 @@
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage } from './types';
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from './types';
 
 const accountSid = 'ACfd932bd76669f9cc2145e67e6c3e03ea';
 const flexFlowSid = 'FOe37919dd07e25959ef5c480519270d91';
 const defaultLanguage = 'en-US';
 const captureIp = true;
+const contactType: ContactType = 'ip';
 
 const translations: Translations = {
   'en-US': {
@@ -52,4 +53,5 @@ export const config: Configuration = {
   mapHelplineLanguage,
   memberDisplayOptions,
   captureIp,
+  contactType
 };

--- a/configurations/hu-staging.ts
+++ b/configurations/hu-staging.ts
@@ -1,10 +1,11 @@
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage } from './types';
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from './types';
 
 const accountSid = 'ACbdbee34ef7d099e71cf095d540ff3270';
 const flexFlowSid = 'FO9d20dbe99abbc3b9ad7709f961b0fe95';
 const defaultLanguage = 'ukr-HU';
 const captureIp = false;
 const checkOpenHours = true;
+const contactType: ContactType = 'ip';
 
 const translations: Translations = {
     'en-US': {
@@ -138,4 +139,5 @@ export const config: Configuration = {
   captureIp,
   checkOpenHours,
   closedHours,
+  contactType
 };

--- a/configurations/jm-staging.ts
+++ b/configurations/jm-staging.ts
@@ -1,9 +1,10 @@
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage } from './types';
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from './types';
 
 const accountSid = 'ACbc27263c18e621f3deb57cf1998a4e04';
 const flexFlowSid = 'FOfe4a6c70afb6460dff8a7c2b1503b7aa';
 const defaultLanguage = 'en-US';
 const captureIp = true;
+const contactType: ContactType = 'ip';
 
 const translations: Translations = {
   'en-US': {
@@ -56,4 +57,5 @@ export const config: Configuration = {
   mapHelplineLanguage,
   memberDisplayOptions,
   captureIp,
+  contactType
 };

--- a/configurations/mt-staging.ts
+++ b/configurations/mt-staging.ts
@@ -3,12 +3,14 @@ import {
   Translations,
   Configuration,
   MapHelplineLanguage,
+  ContactType
 } from './types';
 
 const accountSid = 'ACfb0ccf10880289d67f5c4e85ae26402b';
 const flexFlowSid = 'FOd69e1f3020fd621d4bd9d4be833d8a19';
 const defaultLanguage = 'en-US';
 const captureIp = true;
+const contactType: ContactType = 'ip';
 
 const translations: Translations = {
   'en-US': {
@@ -113,5 +115,5 @@ export const config: Configuration = {
   preEngagementConfig,
   mapHelplineLanguage,
   memberDisplayOptions,
-  captureIp,
+  captureIp,contactType
 };

--- a/configurations/mw-staging.ts
+++ b/configurations/mw-staging.ts
@@ -1,9 +1,10 @@
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage } from './types';
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from './types';
 
 const accountSid = 'AC874af45ec4a696d5d4dca07b0036e2bf';
 const flexFlowSid = 'FO7fb4e9816507d650ddc221f27d2d8927';
 const defaultLanguage = 'en-US';
 const captureIp = true;
+const contactType: ContactType = 'ip';
 
 const translations: Translations = {
   'en-US': {
@@ -51,5 +52,5 @@ export const config: Configuration = {
   preEngagementConfig,
   mapHelplineLanguage,
   memberDisplayOptions,
-  captureIp,
+  captureIp,contactType
 };

--- a/configurations/pl-staging.ts
+++ b/configurations/pl-staging.ts
@@ -1,9 +1,10 @@
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage } from './types';
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from './types';
 
 const accountSid = 'ACb3da2ab24338c616db45ba3b4afce61a';
 const flexFlowSid = 'FO83947facb0df52ee4849d30275334213';
 const defaultLanguage = 'en-US';
 const captureIp = true;
+const contactType: ContactType = 'ip';
 
 const translations: Translations = {
   'en-US': {
@@ -55,5 +56,5 @@ export const config: Configuration = {
   preEngagementConfig,
   mapHelplineLanguage,
   memberDisplayOptions,
-  captureIp,
+  captureIp,contactType
 };

--- a/configurations/ro-staging.ts
+++ b/configurations/ro-staging.ts
@@ -3,12 +3,14 @@ import {
   Translations,
   Configuration,
   MapHelplineLanguage,
+  ContactType
 } from './types';
 
 const accountSid = 'ACbeffd85714fecd060d38aa4d84c3fc03';
 const flexFlowSid = 'FO1991160f1788af24f3c207be5b16f893';
 const defaultLanguage = 'en-US';
 const captureIp = true;
+const contactType: ContactType = 'ip';
 
 const translations: Translations = {
   'en-US': {
@@ -65,5 +67,5 @@ export const config: Configuration = {
   preEngagementConfig,
   mapHelplineLanguage,
   memberDisplayOptions,
-  captureIp,
+  captureIp,contactType,
 };

--- a/configurations/types.ts
+++ b/configurations/types.ts
@@ -23,6 +23,9 @@ export type Configuration = {
   memberDisplayOptions?: MemberDisplayOptions;
   captureIp: boolean;
   checkOpenHours?: boolean;
+  contactType: ContactType;
 };
 
 export type OperatingHoursState = 'open' | 'closed' | 'holiday';
+
+export type ContactType = 'ip' | 'email';

--- a/configurations/uk-staging.ts
+++ b/configurations/uk-staging.ts
@@ -1,9 +1,10 @@
-import {PreEngagementConfig,Translations,Configuration,MapHelplineLanguage} from './types'
+import {PreEngagementConfig,Translations,Configuration,MapHelplineLanguage, ContactType} from './types'
 
 const accountSid = 'AC542ee9a6613ce5ff976d075a3e3bd38d';
 const flexFlowSid = 'FOfe2df2f82dd40be24d41347fff7c6f1c';
 const defaultLanguage ='en-GB';
 const captureIp = true;
+const contactType: ContactType = 'ip';
 
 const preEngagementConfig: PreEngagementConfig = {
   description: "Welcome to the Revenge Porn and Report Harmful Content Helplines.",
@@ -70,5 +71,5 @@ export const config: Configuration = {
   preEngagementConfig,
   mapHelplineLanguage,
   memberDisplayOptions,
-  captureIp,
+  captureIp,contactType,
 };

--- a/configurations/za-staging.ts
+++ b/configurations/za-staging.ts
@@ -1,10 +1,11 @@
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage } from './types';
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from './types';
 
 const accountSid = 'AC16dd71c6fd135ee250bd213ad1efa2e8';
 const flexFlowSid = 'FOd655fd61e9e7ac6faf9d0be97a49863b';
 const defaultLanguage = 'en-US';
 const captureIp = true;
 const checkOpenHours = true;
+const contactType: ContactType = 'ip';
 
 const translations: Translations = {
   'en-US': {
@@ -91,4 +92,5 @@ export const config: Configuration = {
   mapHelplineLanguage,
   memberDisplayOptions,
   captureIp,
+  contactType,
 };

--- a/configurations/zm-staging.ts
+++ b/configurations/zm-staging.ts
@@ -4,6 +4,7 @@ const accountSid = 'ACc59300c7ca018e8652e4d6d86c2d50e6';
 const flexFlowSid = 'FObb9dfe97f1c59f455ab01811bec74cd5';
 const defaultLanguage = 'en-US';
 const captureIp = true;
+const contactType = 'ip'
 
 const translations: Translations = {
   'en-US': {
@@ -182,4 +183,5 @@ export const config: Configuration = {
   mapHelplineLanguage,
   memberDisplayOptions,
   captureIp,
+  contactType
 };

--- a/configurations/zw-staging.ts
+++ b/configurations/zw-staging.ts
@@ -1,9 +1,10 @@
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage } from './types';
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from './types';
 
 const accountSid = 'AC48d146ce2460184b8944cc7fdf8c5d25';
 const flexFlowSid = 'FO7494aba81cf5899543d90aa1902a1064';
 const defaultLanguage = 'en-US';
 const captureIp = true;
+const contactType: ContactType = 'ip';
 
 const translations: Translations = {
   'en-US': {
@@ -57,4 +58,5 @@ export const config: Configuration = {
   mapHelplineLanguage,
   memberDisplayOptions,
   captureIp,
+  contactType
 };

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -55,7 +55,6 @@ const setListenerToUnlockInput = async (channel: Channel, manager: FlexWebChat.M
   });
 };
 
-
 const setChannelOnCreateWebChat = async (channel: Channel, manager: FlexWebChat.Manager) => {
   setListenerToUnlockInput(channel, manager);
 };

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -68,8 +68,7 @@ const setChannelAfterStartEngagement = async (channel: Channel, manager: FlexWeb
 };
 export const initWebchat = async () => {
   let ip: string | undefined;
-
-  if (currentConfig.captureIp) {
+  if (currentConfig.captureIp && currentConfig.contactType === 'ip') {
     ip = await getUserIp();
   }
 
@@ -148,9 +147,11 @@ export const initWebchat = async () => {
     changeLanguageWebChat(language);
 
     const channel = await chatChannel(manager);
-    let contact = ip;
-    if (email) contact = email;
-    await setChannelAfterStartEngagement(channel, manager, contact);
+
+    //Currently only ip and email are sent as contact to be used for identifying a contact by in flex. When more possible contact types are added, this logic will need to be updated
+    const contactConfig = currentConfig.contactType === 'email' ? email : ip;
+
+    await setChannelAfterStartEngagement(channel, manager, contactConfig);
     await subscribeToChannel(manager, channel);
   });
 

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -148,7 +148,7 @@ export const initWebchat = async () => {
 
     const channel = await chatChannel(manager);
 
-    //Currently only ip and email are sent as contact to be used for identifying a contact by in flex. When more possible contact types are added, this logic will need to be updated
+    // Currently only ip and email are sent as contact to be used for identifying a contact by in flex. When more possible contact types are added, this logic will need to be updated
     const contactConfig = currentConfig.contactType === 'email' ? email : ip;
 
     await setChannelAfterStartEngagement(channel, manager, contactConfig);

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -86,6 +86,7 @@ export const initWebchat = async () => {
     preEngagementConfig: currentConfig.preEngagementConfig,
     context: {
       ip,
+      contactType: currentConfig.contactType,
     },
     colorTheme: {
       overrides: {

--- a/src/contact-identifier/index.ts
+++ b/src/contact-identifier/index.ts
@@ -1,0 +1,52 @@
+import * as FlexWebChat from '@twilio/flex-webchat-ui';
+
+import { getCurrentConfig } from '../../configurations';
+
+/**
+ * If contentType is 'ip', we get contactIdentifier from the context.
+ * Otherwise, we get contactIdentifier from the pre-engagement answers.
+ */
+function getContactIdentifier(manager: FlexWebChat.Manager, payload: any) {
+  const { contactType } = getCurrentConfig();
+
+  if (contactType === 'ip') {
+    return manager.configuration.context.ip;
+  }
+
+  return payload.formData.contactIdentifier;
+}
+
+/**
+ * Creates a new appConfig object based on the current one,
+ * with these new properties at appConfig.context:
+ *  - contactType
+ *  - contactIdentifier
+ */
+function getUpdatedAppConfig(manager: FlexWebChat.Manager, contactIdentifier: string) {
+  const { contactType } = getCurrentConfig();
+  const appConfig = manager.configuration;
+
+  // TODO: remove IP from context when possible
+  return {
+    ...appConfig,
+    context: {
+      ...appConfig.context,
+      contactIdentifier,
+      contactType,
+    },
+  };
+}
+
+/**
+ * On 'beforeStartEngagement' event, adds to webchat context:
+ *  - contactType
+ *  - contactIdentifier
+ */
+export function addContactIdentifierToContext(manager: FlexWebChat.Manager) {
+  FlexWebChat.Actions.addListener('beforeStartEngagement', async (payload) => {
+    const contactIdentifier = getContactIdentifier(manager, payload);
+    const updatedAppConfig = getUpdatedAppConfig(manager, contactIdentifier);
+
+    manager.updateConfig(updatedAppConfig);
+  });
+}


### PR DESCRIPTION
<!-- Tag the primary responsible for reviewing this PR. If in doubt who can take this, ask first. -->
Note: This PR should be reviewed with this Flex's PR https://github.com/techmatters/flex-plugins/pull/1146

Primary reviewer: @murilovmachado

## Description
- This PR replaces `ip` with an abstracted `contactType` to support ip, email, and any other contact identifier in the future. Currently, only supports 'ip' and 'email'
`context: {
      ip,
      **contactType: currentConfig.contactType,**
    },
    `
- Introduces a new option `contactType` and updated all helpline configurations to support `contactType`. Currently, `dev` is set to 'email' for testing. Rest of the configurations are set to 'ip'
`const contactType: ContactType = 'email';`
- AutoFirstMessage updated to send contact based on `contactType` in configuration. This can be checked in flex

### Checklist
- [x] Corresponding issue has been opened
- [n/a] New tests added
- [n/a] Strings are localized
- [x] Tested for chat contacts

### Related Issues
Fixes #[1354](https://tech-matters.atlassian.net/browse/CHI-1354)

### Verification steps
Note: Email as an input in preEngagementData has already been added to test in `dev` config. 
- Initiate webchat and add email at pre-engagement prompt, and get to chat engagement status with a counsellor (accept task in flex) 
- This PR should be reviewed alongside https://github.com/techmatters/flex-plugins/pull/1146
- Check the first message and also the PreviousContactsBanner for an email contact instead of the usual ip address
![Screenshot 2022-12-26 at 11 13 24 AM](https://user-images.githubusercontent.com/102122005/209566751-f0adf9f9-889e-43c9-b36e-88e8f7847d6e.png)

