### PR TITLE
chore: add ignores to license add script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,12 @@
     "build": "cross-env webpack",
     "lint": "eslint --ext js --ext jsx --ext ts --ext tsx src/",
     "lint:fix": "npm run lint -- --fix",
-    "license:add": "docker run --rm -v ${PWD}:/src ghcr.io/google/addlicense -c \"Technology Matters\" -y \"2021-2023\" -f license-header.tpl .",
-    "license:check": "docker run --rm -v ${PWD}:/src ghcr.io/google/addlicense -check -c \"Technology Matters\" -y \"2021-2023\" -f license-header.tpl ."
+    "license:add": "docker run --rm -v ${PWD}:/src ghcr.io/google/addlicense -c \"Technology Matters\" -y \"2021-2023\" -ignore \"**/node_modules/**\" -ignore \"**/dist/**\" -ignore \"**/coverage/**\" -f license-header.tpl .",
+    "license:check": "docker run --rm -v ${PWD}:/src ghcr.io/google/addlicense -check -c \"Technology Matters\" -y \"2021-2023\" -ignore \"**/node_modules/**\" -ignore \"**/dist/**\" -ignore \"**/coverage/**\" -f license-header.tpl .",
+    "license:add:windows": "docker run --rm -v %cd%:/src ghcr.io/google/addlicense -c \"Technology Matters\" -y \"2021-2023\" -ignore \".idea/**\" -ignore \"**/node_modules/**\" -ignore \"**/dist/**\" -ignore \"**/coverage/**\" -f license-header.tpl .",
+    "license:check:windows": "docker run --rm -v %cd%:/src ghcr.io/google/addlicense -check -c \"Technology Matters\" -y \"2021-2023\" -ignore \".idea/**\" -ignore \"**/node_modules/**\" -ignore \"**/dist/**\" -ignore \"**/coverage/**\" **/build-f license-header.tpl .",
+    "license:add:windows:local": "addlicense -c \"Technology Matters\" -y \"2021-2023\" -ignore .idea\\\\** -ignore node_modules\\\\** -ignore \"**\\\\node_modules\\\\**\" -ignore \"**\\\\dist\\\\**\" -ignore \"**\\\\coverage\\\\**\" -ignore cdk.out\\\\** -f license-header.tpl .",
+    "license:check:windows:local": "addlicense -check -c \"Technology Matters\" -y \"2021-2023\" -ignore .idea\\\\** -ignore node_modules\\\\** -ignore \"**\\\\node_modules\\\\**\" -ignore \"**\\\\dist\\\\**\" -ignore \"**\\\\coverage\\\\**\" -ignore cdk.out\\\\** -f license-header.tpl ."
   },
   "devDependencies": {
     "@babel/core": "^7.19.0",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "license:check": "docker run --rm -v ${PWD}:/src ghcr.io/google/addlicense -check -c \"Technology Matters\" -y \"2021-2023\" -ignore \"**/node_modules/**\" -ignore \"**/dist/**\" -ignore \"**/coverage/**\" -f license-header.tpl .",
     "license:add:windows": "docker run --rm -v %cd%:/src ghcr.io/google/addlicense -c \"Technology Matters\" -y \"2021-2023\" -ignore \".idea/**\" -ignore \"**/node_modules/**\" -ignore \"**/dist/**\" -ignore \"**/coverage/**\" -f license-header.tpl .",
     "license:check:windows": "docker run --rm -v %cd%:/src ghcr.io/google/addlicense -check -c \"Technology Matters\" -y \"2021-2023\" -ignore \".idea/**\" -ignore \"**/node_modules/**\" -ignore \"**/dist/**\" -ignore \"**/coverage/**\" **/build-f license-header.tpl .",
-    "license:add:windows:local": "addlicense -c \"Technology Matters\" -y \"2021-2023\" -ignore .idea\\\\** -ignore node_modules\\\\** -ignore \"**\\\\node_modules\\\\**\" -ignore \"**\\\\dist\\\\**\" -ignore \"**\\\\coverage\\\\**\" -ignore cdk.out\\\\** -f license-header.tpl .",
-    "license:check:windows:local": "addlicense -check -c \"Technology Matters\" -y \"2021-2023\" -ignore .idea\\\\** -ignore node_modules\\\\** -ignore \"**\\\\node_modules\\\\**\" -ignore \"**\\\\dist\\\\**\" -ignore \"**\\\\coverage\\\\**\" -ignore cdk.out\\\\** -f license-header.tpl ."
+    "license:add:windows:local": "addlicense -c \"Technology Matters\" -y \"2021-2023\" -ignore .idea\\\\** -ignore node_modules\\\\** -ignore \"**\\\\node_modules\\\\**\" -ignore \"**\\\\dist\\\\**\" -ignore \"**\\\\coverage\\\\**\" -f license-header.tpl .",
+    "license:check:windows:local": "addlicense -check -c \"Technology Matters\" -y \"2021-2023\" -ignore .idea\\\\** -ignore node_modules\\\\** -ignore \"**\\\\node_modules\\\\**\" -ignore \"**\\\\dist\\\\**\" -ignore \"**\\\\coverage\\\\**\" -f license-header.tpl ."
   },
   "devDependencies": {
     "@babel/core": "^7.19.0",


### PR DESCRIPTION
Adds ignore patterns (not all but the important ones... hopefully?) to the license add command and windows versions.