### PR TITLE
Added support for new response from operatingInfo

### DIFF
--- a/src/operating-hours.ts
+++ b/src/operating-hours.ts
@@ -16,14 +16,14 @@
 
 import { Manager } from '@twilio/flex-webchat-ui';
 
-import { Configuration, OperatingHoursState } from '../types';
+import { Configuration, OperatingHoursResponse } from '../types';
 
-const getOperatingHours = async (): Promise<OperatingHoursState> => {
-  const body = { channel: 'webchat' };
+const getOperatingHours = async (language: string): Promise<OperatingHoursResponse> => {
+  const body = { channel: 'webchat', useV2: 'true', language };
 
   const options = {
     method: 'POST',
-    body: new URLSearchParams({ ...body }),
+    body: new URLSearchParams(body),
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
     },
@@ -51,11 +51,27 @@ export const displayOperatingHours = async (config: Configuration, manager: Mana
   // If a helpline has operating hours configuration set, the pre engagement config will show alternative canvas during closed or holiday times/days
   if (config.checkOpenHours) {
     try {
-      const operatingState = await getOperatingHours();
-      if (operatingState === 'closed' && config.closedHours) {
-        manager.updateConfig({ preEngagementConfig: config.closedHours });
-      } else if (operatingState === 'holiday' && config.holidayHours) {
-        manager.updateConfig({ preEngagementConfig: config.holidayHours });
+      const operatingState = await getOperatingHours(config.defaultLanguage);
+
+      /*
+       * Support legacy function to avoid braking changes
+       * TODO: remove once every account has been migrated
+       */
+      if (typeof operatingState === 'string') {
+        if (operatingState === 'closed' && config.closedHours) {
+          manager.updateConfig({ preEngagementConfig: config.closedHours });
+        } else if (operatingState === 'holiday' && config.holidayHours) {
+          manager.updateConfig({ preEngagementConfig: config.holidayHours });
+        }
+      } else {
+        // eslint-disable-next-line no-lonely-if
+        if (operatingState.status === 'closed' && config.closedHours) {
+          manager.updateConfig({ preEngagementConfig: { ...config.closedHours, description: operatingState.message } });
+        } else if (operatingState.status === 'holiday' && config.holidayHours) {
+          manager.updateConfig({
+            preEngagementConfig: { ...config.holidayHours, description: operatingState.message },
+          });
+        }
       }
     } catch (error) {
       console.log(error);

--- a/src/operating-hours.ts
+++ b/src/operating-hours.ts
@@ -47,6 +47,7 @@ const getOperatingHours = async (language: string): Promise<OperatingHoursRespon
   return responseJson;
 };
 
+// eslint-disable-next-line sonarjs/cognitive-complexity
 export const displayOperatingHours = async (config: Configuration, manager: Manager) => {
   // If a helpline has operating hours configuration set, the pre engagement config will show alternative canvas during closed or holiday times/days
   if (config.checkOpenHours) {

--- a/types.ts
+++ b/types.ts
@@ -42,6 +42,7 @@ export type Configuration = {
   contactType: ContactType;
 };
 
-export type OperatingHoursState = 'open' | 'closed' | 'holiday';
+type OperatingHoursStatus = 'open' | 'closed' | 'holiday';
+export type OperatingHoursResponse = OperatingHoursStatus | { status: OperatingHoursStatus; message: string };
 
 export type ContactType = 'ip' | 'email';


### PR DESCRIPTION
## Description
This PR extends support for the new response from operatingHours function (https://github.com/techmatters/serverless/pull/409), while preserving the old format (for compatability).

![Screenshot from 2023-02-02 16-04-10](https://user-images.githubusercontent.com/15805319/216438657-20328c19-ea6b-44e8-be26-cb92babb9e6a.png)

![Screenshot from 2023-02-02 16-01-10](https://user-images.githubusercontent.com/15805319/216438687-2a630d99-ca04-4d46-9527-d9a5e13c2625.png)

Note: we don't have language info before pre-engagement, so the message will always be in the configured default language.

### Checklist
- [x] [Corresponding issue has been opened](https://tech-matters.atlassian.net/jira/software/c/projects/CHI/boards/7?modal=detail&selectedIssue=CHI-1635)
- [ ] New tests added

### Verification steps
- Start serverless locally while sitting in https://github.com/techmatters/serverless/pull/409, and expose the url via ngrok.
- Add `export const SERVERLESS_URL = <above url>;` to `private/secret.ts`.
- Confirm that the functionality is working as expected, depending on `assets/operatingInfo/aselo-dev.private.json` (serverless):
  - `operatingHours -> webchat` is "always open" (`[{ "open": 0, "close": 2400 }]`) should allow to initiate a webchat conversation.
  - `operatingHours -> webchat` is "always closed" (`[]`) should prevent to initiate a webchat conversation with the "closed due to shift" message.
  - Adding an entry like `"holidays": { "<your current date>": "Something"  },` should prevent to initiate a webchat conversation with the "closed due to holiday" message. 