### PR TITLE
Web page language detection

### DIFF
--- a/configurations/ca-staging.ts
+++ b/configurations/ca-staging.ts
@@ -14,812 +14,804 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import {
-    PreEngagementConfig,
-    Translations,
-    Configuration,
-    MapHelplineLanguage,
-    ContactType
-  } from '../types';
-  
-  const accountSid = 'ACeb335f4685aa874fddf00cdd7c2946bd';
-  const flexFlowSid = 'FO45c6ac308207b8b17bd990eadf5246fe';
-  const defaultLanguage = 'en-CA';
-  const captureIp = false;
-  const checkOpenHours = false;
-  const contactType: ContactType = 'ip';
-  const translations: Translations = {
-    'en-CA': {
-      MessageInputDisabledReasonHold:
-        "Thank you! Please hold for a counsellor.",
-      EntryPointTagLine: 'Chat with us',
-      PreEngagementDescription: "Let's get started",
-      Today: 'Today',
-      InputPlaceHolder: 'Type Message',
-      WelcomeMessage: 'Welcome to Kids Help Phone. ',
-      Yesterday: 'Yesterday',
-      TypingIndicator: 'Counsellor is typing',
-      MessageCanvasTrayButton: 'Start New Chat',
-      MessageCanvasTrayContent: '',
-      AutoFirstMessage: 'Incoming webchat contact from',
-      StartChat: 'Start Chat!',
-    }
-  };
-  
-  const preEngagementConfig: PreEngagementConfig = {
-    description: "Welcome to Kids Help Phone. To help us serve you better, please answer the following questions.",
-    fields:
-      [
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
+
+const accountSid = 'ACeb335f4685aa874fddf00cdd7c2946bd';
+const flexFlowSid = 'FO45c6ac308207b8b17bd990eadf5246fe';
+const defaultLanguage = 'en-CA';
+const captureIp = false;
+const checkOpenHours = false;
+const contactType: ContactType = 'ip';
+const translations: Translations = {
+  'en-CA': {
+    MessageInputDisabledReasonHold: 'Thank you! Please hold for a counsellor.',
+    EntryPointTagLine: 'Chat with us',
+    PreEngagementDescription: "Let's get started",
+    Today: 'Today',
+    InputPlaceHolder: 'Type Message',
+    WelcomeMessage: 'Welcome to Kids Help Phone. ',
+    Yesterday: 'Yesterday',
+    TypingIndicator: 'Counsellor is typing',
+    MessageCanvasTrayButton: 'Start New Chat',
+    MessageCanvasTrayContent: '',
+    AutoFirstMessage: 'Incoming webchat contact from',
+    StartChat: 'Start Chat!',
+  },
+};
+
+const preEngagementConfig: PreEngagementConfig = {
+  description: 'Welcome to Kids Help Phone. To help us serve you better, please answer the following questions.',
+  fields: [
+    {
+      type: 'InputItem',
+      label: 'Nickname (please do not share your real name)',
+      attributes: {
+        name: 'nickname',
+        type: 'text',
+        placeholder: 'Guest',
+        required: true,
+      },
+    },
+    {
+      label: 'How old are you?',
+      type: 'SelectItem',
+      attributes: {
+        name: 'age',
+        required: true,
+        readOnly: false,
+      },
+      options: [
         {
-          type: "InputItem",
-          label: "Nickname (please do not share your real name)",
-          attributes: {
-            name: "nickname",
-            type: "text",
-            placeholder: "Guest",
-            required: true,
-          },
+          value: '5 or younger',
+          label: '5 or younger',
+          selected: true,
         },
         {
-            label: 'How old are you?',
-            type: 'SelectItem',
-            attributes: {
-              name: 'age',
-              required: true,
-              readOnly: false,
-            },
-            options: [
-              {
-                value: '5 or younger',
-                label: '5 or younger',
-                selected: true,
-              },
-              {
-                value: '06',
-                label: '6',
-                selected: false,
-              },
-              {
-                value: '07',
-                label: '7',
-                selected: false,
-              },
-              {
-                value: '08',
-                label: '8',
-                selected: false,
-              },
-              {
-                value: '09',
-                label: '9',
-                selected: false,
-              },
-              {
-                value: '10',
-                label: '10',
-                selected: false,
-              },
-              {
-                value: '11',
-                label: '11',
-                selected: false,
-              },              
-              {
-                value: '12',
-                label: '12',
-                selected: false,
-              },     
-              {
-                value: '13',
-                label: '13',
-                selected: false,
-              },     
-              {
-                value: '14',
-                label: '14',
-                selected: false,
-              },     
-              {
-                value: '15',
-                label: '15',
-                selected: false,
-              },     
-              {
-                value: '16',
-                label: '16',
-                selected: false,
-              },     
-              {
-                value: '17',
-                label: '17',
-                selected: false,
-              },     
-              {
-                value: '18',
-                label: '18',
-                selected: false,
-              },     
-              {
-                value: '19',
-                label: '19',
-                selected: false,
-              },   
-              {
-                value: '20',
-                label: '20',
-                selected: false,
-              },
-              {
-                value: '21',
-                label: '21',
-                selected: false,
-              },              
-              {
-                value: '22',
-                label: '22',
-                selected: false,
-              },     
-              {
-                value: '23',
-                label: '23',
-                selected: false,
-              },     
-              {
-                value: '24',
-                label: '24',
-                selected: false,
-              },     
-              {
-                value: '25',
-                label: '25',
-                selected: false,
-              },     
-              {
-                value: '26',
-                label: '26',
-                selected: false,
-              },     
-              {
-                value: '27',
-                label: '27',
-                selected: false,
-              },     
-              {
-                value: '28',
-                label: '28',
-                selected: false,
-              },     
-              {
-                value: '29',
-                label: '29',
-                selected: false,
-              },   
-              {
-                value: '>30',
-                label: '>30',
-                selected: false,
-              },   
-              {
-                value: 'Unknown',
-                label: 'Prefer not to answer',
-                selected: false,
-              },      
-            ],
-          },
-          {
-            label: 'Do you consider yourself to be:',
-            type: 'SelectItem',
-            attributes: {
-              name: 'gender',
-              required: true,
-              readOnly: false,
-            },
-            options: [
-              {
-                value: 'Agender',
-                label: 'Agender',
-                selected: true,
-              },
-              {
-                value: 'Cis Male/Man',
-                label: 'Cis Male/Man',
-                selected: false,
-              },
-              {
-                value: 'Cis Female/Woman',
-                label: 'Cis Female/Woman',
-                selected: false,
-              },
-              {
-                value: 'Non-Binary/Genderqueer/Gender fluid"',
-                label: 'Non-Binary/Genderqueer/Gender fluid"',
-                selected: false,
-              },
-              {
-                value: 'Two-Spirit',
-                label: 'Two-Spirit',
-                selected: false,
-              },
-              {
-                value: 'Trans Female/Woman',
-                label: 'Trans Female/Woman',
-                selected: false,
-              },
-              {
-                value: 'Trans Male/Man',
-                label: 'Trans Male/Man',
-                selected: false,
-              },
-              {
-                value: 'Other',
-                label: 'Other',
-                selected: false,
-              },
-              {
-                value: 'Unknown',
-                label: 'Prefer not to answer',
-                selected: false,
-              },
-            ],
-          },
-          {
-          label: 'Do you consider yourself to be:',
-          type: 'SelectItem',
-          attributes: {
-            name: 'sexualOrientation',
-            required: true,
-            readOnly: false,
-          },
-          options: [
-            {
-              value: 'Asexual',
-              label: 'Asexual',
-              selected: true,
-            },
-            {
-              value: 'Bisexual or Pansexual',
-              label: 'Bisexual or Pansexual',
-              selected: false,
-            },
-            {
-              value: 'Gay or Lesbian',
-              label: 'Gay or Lesbian',
-              selected: false,
-            },
-            {
-              value: 'Queer',
-              label: 'Queer',
-              selected: false,
-            },
-            {
-              value: 'Heterosexual or Straight',
-              label: 'Heterosexual or Straight',
-              selected: false,
-            },
-            {
-              value: 'Questioning or Unsure',
-              label: 'Questioning or Unsure',
-              selected: false,
-            },
-            {
-              value: 'Other',
-              label: 'Other',
-              selected: false,
-            },
-            {
-              value: 'Unknown',
-              label: 'Prefer not to answer',
-              selected: false,
-            },
-          ],
+          value: '06',
+          label: '6',
+          selected: false,
         },
         {
-          label: 'Are you a newcomer (i.e., Arrived in Canada within 5 years or less), recent immigrant, and/or refugee?',
-          type: 'SelectItem',
-          attributes: {
-            name: 'Newcomer',
-            required: true,
-          },
-          options: [
-            {
-              value: 'yes',
-              label: 'Yes',
-              selected: true,
-            },
-            {
-              value: 'no',
-              label: 'No',
-              selected: false,
-            },
-            {
-              value: 'Unknown',
-              label: 'Prefer not to answer',
-              selected: false,
-            },
-          ],
+          value: '07',
+          label: '7',
+          selected: false,
         },
         {
-          label: 'What province or territory do you live in? ',
-          type: 'SelectItem',
-          attributes: {
-            name: 'province',
-            required: true,
-          },
-          options: [
-            {
-              value: 'Alberta',
-              label: 'Alberta',
-              selected: true,
-            },
-            {
-              value: 'British Columbia',
-              label: 'British Columbia',
-              selected: false,
-            },
-            {
-              value: 'Inuvialuit',
-              label: 'Inuvialuit',
-              selected: false,
-            },
-            {
-              value: 'Manitoba',
-              label: 'Manitoba',
-              selected: false,
-            },
-            {
-              value: 'New Brunswick',
-              label: 'New Brunswick',
-              selected: false,
-            },
-            {
-              value: 'Newfoundland and Labrador',
-              label: 'Newfoundland and Labrador',
-              selected: false,
-            },
-            {
-              value: 'Northwest Territories',
-              label: 'Northwest Territories',
-              selected: false,
-            },
-            {
-              value: 'Nova Scotia',
-              label: 'Nova Scotia',
-              selected: false,
-            },
-            {
-              value: 'Nunavat',
-              label: 'Nunavat',
-              selected: false,
-            },
-            {
-              value: 'Nunavik',
-              label: 'Nunavik',
-              selected: false,
-            },
-            {
-              value: 'Nunatsiavut',
-              label: 'Nunatsiavut',
-              selected: false,
-            },
-            {
-              value: 'Ontario',
-              label: 'Ontario',
-              selected: false,
-            },
-            {
-              value: 'Prince Edward Island',
-              label: 'Prince Edward Island',
-              selected: false,
-            },
-            {
-              value: 'Québec',
-              label: 'Québec',
-              selected: false,
-            },
-            {
-              value: 'Saskatchewan',
-              label: 'Saskatchewan',
-              selected: false,
-            },
-            {
-              value: 'Yukon',
-              label: 'Yukon',
-              selected: false,
-            },
-            {
-              value: 'Contacting us from outside of Canada',
-              label: 'Contacting us from outside of Canada',
-              selected: false,
-            },
-            {
-              value: 'Did not disclose/Did not ask',
-              label: 'Prefer not to answer',
-              selected: false,
-            },
-          ],
+          value: '08',
+          label: '8',
+          selected: false,
         },
         {
-          label: 'Tell us more about where you live…',
-          type: 'SelectItem',
-          attributes: {
-            name: 'region',
-            required: true,
-          },
-          options: [
-            {
-              value: 'Rural area',
-              label: 'Rural area (less than 1,000 people)',
-              selected: true,
-            },
-            {
-              value: 'Small city/town',
-              label: 'Small city/town (approximately 1,000 to 29,999 people)',
-              selected: false,
-            },
-            {
-              value: 'Medium city',
-              label: 'Medium city (approximately 30,000 to 99,999 people)',
-              selected: false,
-            },
-            {
-              value: 'Large city/urban centre',
-              label: 'Large city/urban centre (approximately 100,000 people or more)',
-              selected: false,
-            },
-            {
-              value: 'First Nations reserve',
-              label: 'First Nations reserve',
-              selected: false,
-            },
-            {
-              value: 'Other',
-              label: 'Other',
-              selected: false,
-            },
-            {
-              value: 'Unknown',
-              label: 'Prefer not to answer',
-              selected: false,
-            },
-          ],
+          value: '09',
+          label: '9',
+          selected: false,
         },
         {
-          label: 'On a scale of 1 to 7, how upset are you right now?',
-          type: 'SelectItem',
-          attributes: {
-            name: 'upset',
-            required: true,
-          },
-          options: [
-            {
-              value: '1',
-              label: '1 - Not Very',
-              selected: true,
-            },
-            {
-              value: '2',
-              label: '2',
-              selected: false,
-            },
-            {
-              value: '3',
-              label: '3',
-              selected: false,
-            },
-            {
-              value: '4',
-              label: '4',
-              selected: false,
-            },
-            {
-              value: '5',
-              label: '5',
-              selected: false,
-            },
-            {
-              value: '6',
-              label: '6',
-              selected: false,
-            },
-            {
-              value: '7',
-              label: '7 - Very',
-              selected: false,
-            },
-          ],
+          value: '10',
+          label: '10',
+          selected: false,
         },
         {
-          label: 'Do you consider yourself to be:',
-          type: 'SelectItem',
-          attributes: {
-            name: 'ethnicity',
-            required: false,
-          },
-          options: [
-            {
-              value: '',
-              label: '',
-              selected: true,
-            },          
-            {
-              value: 'Black',
-              label: 'Black (e.g., African, Afro-Caribbean, African Canadian descent)',
-              selected: false,
-            },
-            {
-              value: 'East Asian',
-              label: 'East Asian (e.g., East Asian descent; Korean, Chinese, Japanese, etc.)',
-              selected: false,
-            },
-            {
-              value: 'Indigenous',
-              label: 'Indigenous (To North America',
-              selected: false,
-            },
-            {
-              value: 'First Nations',
-              label: 'First Nations [sub-category of Indigenous (To North America)]',
-              selected: false,
-            },
-            {
-              value: 'Métis',
-              label: 'Métis [sub-category of Indigenous (To North America)]',
-              selected: false,
-            },
-            {
-              value: 'Inuit',
-              label: 'Inuit [sub-category of Indigenous (To North America)]',
-              selected: false,
-            },
-            {
-              value: 'Indigenous (non-specified)',
-              label: 'Indigenous (non-specified) [sub-category of Indigenous (To North America)]',
-              selected: false,
-            },
-            {
-              value: 'Indigenous (Not to North America)',
-              label: 'Indigenous (Not to North America)',
-              selected: false,
-            },
-            {
-              value: 'Latin American',
-              label: 'Latin American (e.g., Latin American, Hispanic descent)',
-              selected: false,
-            },
-            {
-              value: 'Middle Eastern',
-              label: 'Middle Eastern (e.g., Arab, Persian, West Asian descent; Egyptian, Iranian, Lebanese, Turkish, etc.)',
-              selected: false,
-            },
-            {
-              value: 'Southeast Asian',
-              label: 'Southeast Asian (e.g., Southeast Asian descent; Cambodian, Filipino, Indonesian, Laotian, Vietnamese, etc.)',
-              selected: false,
-            },
-            {
-              value: 'South Asian',
-              label: 'South Asian (e.g., South Asian descent; East Indian, Afghan, Pakistani, Sri Lankan, etc.)',
-              selected: false,
-            },
-            {
-              value: 'White',
-              label: 'White (e.g., European descent)',
-              selected: false,
-            },
-            {
-              value: 'Other',
-              label: 'Other',
-              selected: false,
-            },
-            {
-              value: 'Unknown',
-              label: 'Prefer not to answer',
-              selected: false,
-            },
-          ],
+          value: '11',
+          label: '11',
+          selected: false,
         },
         {
-          label: 'We would like to learn more about you and if you are currently a student. Do you attend...?',
-          type: 'SelectItem',
-          attributes: {
-            name: 'school',
-            required: false,
-          },
-          options: [
-            {
-              value: '',
-              label: '',
-              selected: true,
-            },
-            {
-              value: 'Elementary School',
-              label: 'Elementary School',
-              selected: false,
-            },
-            {
-              value: 'Middle school/Junior High',
-              label: 'Middle school/Junior High',
-              selected: false,
-            },
-            {
-              value: 'High School',
-              label: 'High School',
-              selected: false,
-            },
-            {
-              value: 'Alternative Education School/Program',
-              label: 'Alternative Education School/Program',
-              selected: false,
-            },
-            {
-              value: 'College',
-              label: 'College',
-              selected: false,
-            },
-            {
-              value: 'University',
-              label: 'University',
-              selected: false,
-            },
-            {
-              value: 'Home School',
-              label: 'Home School',
-              selected: false,
-            },
-            {
-              value: 'Other',
-              label: 'Other',
-              selected: false,
-            },
-            {
-              value: 'Not a student',
-              label: 'Not a student',
-              selected: false,
-            },
-            {
-              value: 'Unknown',
-              label: 'Prefer not to answer',
-              selected: false,
-            },
-          ],
+          value: '12',
+          label: '12',
+          selected: false,
         },
         {
-          label: 'Which of these best describes your current living situation?:',
-          type: 'SelectItem',
-          attributes: {
-            name: 'livingSituation',
-            required: false,
-          },
-          options: [
-            {
-              value: '',
-              label: '',
-              selected: true,
-            },
-            {
-              value: 'Living with family members/guardians',
-              label: 'Living with family members/guardians',
-              selected: false,
-            },
-            {
-              value: 'Member of a military family',
-              label: 'Member of a military family',
-              selected: false,
-            },
-            {
-              value: 'Living independently/with peers',
-              label: 'Living independently/with peers',
-              selected: false,
-            },
-            {
-              value: 'Living in a School residence',
-              label: 'Living in a School residence',
-              selected: false,
-            },
-            {
-              value: 'In hospital',
-              label: 'In hospital',
-              selected: false,
-            },
-            {
-              value: 'Treatment centre',
-              label: 'Treatment centre',
-              selected: false,
-            },
-            {
-              value: 'Recovery home',
-              label: 'Recovery home',
-              selected: false,
-            },
-            {
-              value: 'Assisted living centre',
-              label: 'Assisted living centre',
-              selected: false,
-            },
-            {
-              value: 'Homeless',
-              label: 'Homeless (living in a shelter, on the streets or staying with people temporarily)',
-              selected: false,
-            },
-            {
-              value: 'In care',
-              label: 'In care',
-              selected: false,
-            },
-            {
-              value: 'Other',
-              label: 'Other',
-              selected: false,
-            },
-            {
-              value: 'Unknown',
-              label: 'Prefer not to answer',
-              selected: false,
-            },
-          ],
+          value: '13',
+          label: '13',
+          selected: false,
+        },
+        {
+          value: '14',
+          label: '14',
+          selected: false,
+        },
+        {
+          value: '15',
+          label: '15',
+          selected: false,
+        },
+        {
+          value: '16',
+          label: '16',
+          selected: false,
+        },
+        {
+          value: '17',
+          label: '17',
+          selected: false,
+        },
+        {
+          value: '18',
+          label: '18',
+          selected: false,
+        },
+        {
+          value: '19',
+          label: '19',
+          selected: false,
+        },
+        {
+          value: '20',
+          label: '20',
+          selected: false,
+        },
+        {
+          value: '21',
+          label: '21',
+          selected: false,
+        },
+        {
+          value: '22',
+          label: '22',
+          selected: false,
+        },
+        {
+          value: '23',
+          label: '23',
+          selected: false,
+        },
+        {
+          value: '24',
+          label: '24',
+          selected: false,
+        },
+        {
+          value: '25',
+          label: '25',
+          selected: false,
+        },
+        {
+          value: '26',
+          label: '26',
+          selected: false,
+        },
+        {
+          value: '27',
+          label: '27',
+          selected: false,
+        },
+        {
+          value: '28',
+          label: '28',
+          selected: false,
+        },
+        {
+          value: '29',
+          label: '29',
+          selected: false,
+        },
+        {
+          value: '>30',
+          label: '>30',
+          selected: false,
+        },
+        {
+          value: 'Unknown',
+          label: 'Prefer not to answer',
+          selected: false,
         },
       ],
-    submitLabel: "Start Chat!",
-  };
-  
-  const closedHours: PreEngagementConfig = {
-    description: "We're sorry, but Live Chat is currently closed. :( \nTo reach a Kids Help Phone counsellor, call us anytime at 1-800-668-6868. \nBe well, \nThe Kids Help Phone Team",
-    fields:
-      [
-        {
-          label: 'Hidden Field',
-          type: 'InputField',
-          attributes: {
-            name: '',
-            required: true,
-            readOnly: true,
-          },
-        },
-      ],
-  };
-  
-  const holidayHours: PreEngagementConfig = {
-    description: "We're sorry, but Live Chat is currently closed. :( \nTo reach a Kids Help Phone counsellor, call us anytime at 1-800-668-6868. \nBe well, \n\The Kids Help Phone Team",
-    fields:
-      [
-        {
-          label: 'Hidden Field',
-          type: 'InputField',
-          attributes: {
-            name: '',
-            required: true,
-            readOnly: true,
-          },
-        },
-      ],
-  };
-  
-  const memberDisplayOptions = {
-    yourDefaultName: 'You',
-    yourFriendlyNameOverride: false,
-    theirFriendlyNameOverride: false,
-    theirDefaultName: 'Counsellor',
+    },
+    {
+      label: 'Do you consider yourself to be:',
+      type: 'SelectItem',
+      attributes: {
+        name: 'gender',
+        required: true,
+        readOnly: false,
+      },
+      options: [
+        {
+          value: 'Agender',
+          label: 'Agender',
+          selected: true,
+        },
+        {
+          value: 'Cis Male/Man',
+          label: 'Cis Male/Man',
+          selected: false,
+        },
+        {
+          value: 'Cis Female/Woman',
+          label: 'Cis Female/Woman',
+          selected: false,
+        },
+        {
+          value: 'Non-Binary/Genderqueer/Gender fluid"',
+          label: 'Non-Binary/Genderqueer/Gender fluid"',
+          selected: false,
+        },
+        {
+          value: 'Two-Spirit',
+          label: 'Two-Spirit',
+          selected: false,
+        },
+        {
+          value: 'Trans Female/Woman',
+          label: 'Trans Female/Woman',
+          selected: false,
+        },
+        {
+          value: 'Trans Male/Man',
+          label: 'Trans Male/Man',
+          selected: false,
+        },
+        {
+          value: 'Other',
+          label: 'Other',
+          selected: false,
+        },
+        {
+          value: 'Unknown',
+          label: 'Prefer not to answer',
+          selected: false,
+        },
+      ],
+    },
+    {
+      label: 'Do you consider yourself to be:',
+      type: 'SelectItem',
+      attributes: {
+        name: 'sexualOrientation',
+        required: true,
+        readOnly: false,
+      },
+      options: [
+        {
+          value: 'Asexual',
+          label: 'Asexual',
+          selected: true,
+        },
+        {
+          value: 'Bisexual or Pansexual',
+          label: 'Bisexual or Pansexual',
+          selected: false,
+        },
+        {
+          value: 'Gay or Lesbian',
+          label: 'Gay or Lesbian',
+          selected: false,
+        },
+        {
+          value: 'Queer',
+          label: 'Queer',
+          selected: false,
+        },
+        {
+          value: 'Heterosexual or Straight',
+          label: 'Heterosexual or Straight',
+          selected: false,
+        },
+        {
+          value: 'Questioning or Unsure',
+          label: 'Questioning or Unsure',
+          selected: false,
+        },
+        {
+          value: 'Other',
+          label: 'Other',
+          selected: false,
+        },
+        {
+          value: 'Unknown',
+          label: 'Prefer not to answer',
+          selected: false,
+        },
+      ],
+    },
+    {
+      label: 'Are you a newcomer (i.e., Arrived in Canada within 5 years or less), recent immigrant, and/or refugee?',
+      type: 'SelectItem',
+      attributes: {
+        name: 'Newcomer',
+        required: true,
+      },
+      options: [
+        {
+          value: 'yes',
+          label: 'Yes',
+          selected: true,
+        },
+        {
+          value: 'no',
+          label: 'No',
+          selected: false,
+        },
+        {
+          value: 'Unknown',
+          label: 'Prefer not to answer',
+          selected: false,
+        },
+      ],
+    },
+    {
+      label: 'What province or territory do you live in? ',
+      type: 'SelectItem',
+      attributes: {
+        name: 'province',
+        required: true,
+      },
+      options: [
+        {
+          value: 'Alberta',
+          label: 'Alberta',
+          selected: true,
+        },
+        {
+          value: 'British Columbia',
+          label: 'British Columbia',
+          selected: false,
+        },
+        {
+          value: 'Inuvialuit',
+          label: 'Inuvialuit',
+          selected: false,
+        },
+        {
+          value: 'Manitoba',
+          label: 'Manitoba',
+          selected: false,
+        },
+        {
+          value: 'New Brunswick',
+          label: 'New Brunswick',
+          selected: false,
+        },
+        {
+          value: 'Newfoundland and Labrador',
+          label: 'Newfoundland and Labrador',
+          selected: false,
+        },
+        {
+          value: 'Northwest Territories',
+          label: 'Northwest Territories',
+          selected: false,
+        },
+        {
+          value: 'Nova Scotia',
+          label: 'Nova Scotia',
+          selected: false,
+        },
+        {
+          value: 'Nunavat',
+          label: 'Nunavat',
+          selected: false,
+        },
+        {
+          value: 'Nunavik',
+          label: 'Nunavik',
+          selected: false,
+        },
+        {
+          value: 'Nunatsiavut',
+          label: 'Nunatsiavut',
+          selected: false,
+        },
+        {
+          value: 'Ontario',
+          label: 'Ontario',
+          selected: false,
+        },
+        {
+          value: 'Prince Edward Island',
+          label: 'Prince Edward Island',
+          selected: false,
+        },
+        {
+          value: 'Québec',
+          label: 'Québec',
+          selected: false,
+        },
+        {
+          value: 'Saskatchewan',
+          label: 'Saskatchewan',
+          selected: false,
+        },
+        {
+          value: 'Yukon',
+          label: 'Yukon',
+          selected: false,
+        },
+        {
+          value: 'Contacting us from outside of Canada',
+          label: 'Contacting us from outside of Canada',
+          selected: false,
+        },
+        {
+          value: 'Did not disclose/Did not ask',
+          label: 'Prefer not to answer',
+          selected: false,
+        },
+      ],
+    },
+    {
+      label: 'Tell us more about where you live…',
+      type: 'SelectItem',
+      attributes: {
+        name: 'region',
+        required: true,
+      },
+      options: [
+        {
+          value: 'Rural area',
+          label: 'Rural area (less than 1,000 people)',
+          selected: true,
+        },
+        {
+          value: 'Small city/town',
+          label: 'Small city/town (approximately 1,000 to 29,999 people)',
+          selected: false,
+        },
+        {
+          value: 'Medium city',
+          label: 'Medium city (approximately 30,000 to 99,999 people)',
+          selected: false,
+        },
+        {
+          value: 'Large city/urban centre',
+          label: 'Large city/urban centre (approximately 100,000 people or more)',
+          selected: false,
+        },
+        {
+          value: 'First Nations reserve',
+          label: 'First Nations reserve',
+          selected: false,
+        },
+        {
+          value: 'Other',
+          label: 'Other',
+          selected: false,
+        },
+        {
+          value: 'Unknown',
+          label: 'Prefer not to answer',
+          selected: false,
+        },
+      ],
+    },
+    {
+      label: 'On a scale of 1 to 7, how upset are you right now?',
+      type: 'SelectItem',
+      attributes: {
+        name: 'upset',
+        required: true,
+      },
+      options: [
+        {
+          value: '1',
+          label: '1 - Not Very',
+          selected: true,
+        },
+        {
+          value: '2',
+          label: '2',
+          selected: false,
+        },
+        {
+          value: '3',
+          label: '3',
+          selected: false,
+        },
+        {
+          value: '4',
+          label: '4',
+          selected: false,
+        },
+        {
+          value: '5',
+          label: '5',
+          selected: false,
+        },
+        {
+          value: '6',
+          label: '6',
+          selected: false,
+        },
+        {
+          value: '7',
+          label: '7 - Very',
+          selected: false,
+        },
+      ],
+    },
+    {
+      label: 'Do you consider yourself to be:',
+      type: 'SelectItem',
+      attributes: {
+        name: 'ethnicity',
+        required: false,
+      },
+      options: [
+        {
+          value: '',
+          label: '',
+          selected: true,
+        },
+        {
+          value: 'Black',
+          label: 'Black (e.g., African, Afro-Caribbean, African Canadian descent)',
+          selected: false,
+        },
+        {
+          value: 'East Asian',
+          label: 'East Asian (e.g., East Asian descent; Korean, Chinese, Japanese, etc.)',
+          selected: false,
+        },
+        {
+          value: 'Indigenous',
+          label: 'Indigenous (To North America',
+          selected: false,
+        },
+        {
+          value: 'First Nations',
+          label: 'First Nations [sub-category of Indigenous (To North America)]',
+          selected: false,
+        },
+        {
+          value: 'Métis',
+          label: 'Métis [sub-category of Indigenous (To North America)]',
+          selected: false,
+        },
+        {
+          value: 'Inuit',
+          label: 'Inuit [sub-category of Indigenous (To North America)]',
+          selected: false,
+        },
+        {
+          value: 'Indigenous (non-specified)',
+          label: 'Indigenous (non-specified) [sub-category of Indigenous (To North America)]',
+          selected: false,
+        },
+        {
+          value: 'Indigenous (Not to North America)',
+          label: 'Indigenous (Not to North America)',
+          selected: false,
+        },
+        {
+          value: 'Latin American',
+          label: 'Latin American (e.g., Latin American, Hispanic descent)',
+          selected: false,
+        },
+        {
+          value: 'Middle Eastern',
+          label: 'Middle Eastern (e.g., Arab, Persian, West Asian descent; Egyptian, Iranian, Lebanese, Turkish, etc.)',
+          selected: false,
+        },
+        {
+          value: 'Southeast Asian',
+          label:
+            'Southeast Asian (e.g., Southeast Asian descent; Cambodian, Filipino, Indonesian, Laotian, Vietnamese, etc.)',
+          selected: false,
+        },
+        {
+          value: 'South Asian',
+          label: 'South Asian (e.g., South Asian descent; East Indian, Afghan, Pakistani, Sri Lankan, etc.)',
+          selected: false,
+        },
+        {
+          value: 'White',
+          label: 'White (e.g., European descent)',
+          selected: false,
+        },
+        {
+          value: 'Other',
+          label: 'Other',
+          selected: false,
+        },
+        {
+          value: 'Unknown',
+          label: 'Prefer not to answer',
+          selected: false,
+        },
+      ],
+    },
+    {
+      label: 'We would like to learn more about you and if you are currently a student. Do you attend...?',
+      type: 'SelectItem',
+      attributes: {
+        name: 'school',
+        required: false,
+      },
+      options: [
+        {
+          value: '',
+          label: '',
+          selected: true,
+        },
+        {
+          value: 'Elementary School',
+          label: 'Elementary School',
+          selected: false,
+        },
+        {
+          value: 'Middle school/Junior High',
+          label: 'Middle school/Junior High',
+          selected: false,
+        },
+        {
+          value: 'High School',
+          label: 'High School',
+          selected: false,
+        },
+        {
+          value: 'Alternative Education School/Program',
+          label: 'Alternative Education School/Program',
+          selected: false,
+        },
+        {
+          value: 'College',
+          label: 'College',
+          selected: false,
+        },
+        {
+          value: 'University',
+          label: 'University',
+          selected: false,
+        },
+        {
+          value: 'Home School',
+          label: 'Home School',
+          selected: false,
+        },
+        {
+          value: 'Other',
+          label: 'Other',
+          selected: false,
+        },
+        {
+          value: 'Not a student',
+          label: 'Not a student',
+          selected: false,
+        },
+        {
+          value: 'Unknown',
+          label: 'Prefer not to answer',
+          selected: false,
+        },
+      ],
+    },
+    {
+      label: 'Which of these best describes your current living situation?:',
+      type: 'SelectItem',
+      attributes: {
+        name: 'livingSituation',
+        required: false,
+      },
+      options: [
+        {
+          value: '',
+          label: '',
+          selected: true,
+        },
+        {
+          value: 'Living with family members/guardians',
+          label: 'Living with family members/guardians',
+          selected: false,
+        },
+        {
+          value: 'Member of a military family',
+          label: 'Member of a military family',
+          selected: false,
+        },
+        {
+          value: 'Living independently/with peers',
+          label: 'Living independently/with peers',
+          selected: false,
+        },
+        {
+          value: 'Living in a School residence',
+          label: 'Living in a School residence',
+          selected: false,
+        },
+        {
+          value: 'In hospital',
+          label: 'In hospital',
+          selected: false,
+        },
+        {
+          value: 'Treatment centre',
+          label: 'Treatment centre',
+          selected: false,
+        },
+        {
+          value: 'Recovery home',
+          label: 'Recovery home',
+          selected: false,
+        },
+        {
+          value: 'Assisted living centre',
+          label: 'Assisted living centre',
+          selected: false,
+        },
+        {
+          value: 'Homeless',
+          label: 'Homeless (living in a shelter, on the streets or staying with people temporarily)',
+          selected: false,
+        },
+        {
+          value: 'In care',
+          label: 'In care',
+          selected: false,
+        },
+        {
+          value: 'Other',
+          label: 'Other',
+          selected: false,
+        },
+        {
+          value: 'Unknown',
+          label: 'Prefer not to answer',
+          selected: false,
+        },
+      ],
+    },
+  ],
+  submitLabel: 'Start Chat!',
+};
+
+const closedHours: PreEngagementConfig = {
+  description:
+    "We're sorry, but Live Chat is currently closed. :( \nTo reach a Kids Help Phone counsellor, call us anytime at 1-800-668-6868. \nBe well, \nThe Kids Help Phone Team",
+  fields: [
+    {
+      label: 'Hidden Field',
+      type: 'InputField',
+      attributes: {
+        name: '',
+        required: true,
+        readOnly: true,
+      },
+    },
+  ],
+};
+
+const holidayHours: PreEngagementConfig = {
+  description:
+    "We're sorry, but Live Chat is currently closed. :( \nTo reach a Kids Help Phone counsellor, call us anytime at 1-800-668-6868. \nBe well, \nThe Kids Help Phone Team",
+  fields: [
+    {
+      label: 'Hidden Field',
+      type: 'InputField',
+      attributes: {
+        name: '',
+        required: true,
+        readOnly: true,
+      },
+    },
+  ],
+};
+
+const memberDisplayOptions = {
+  yourDefaultName: 'You',
+  yourFriendlyNameOverride: false,
+  theirFriendlyNameOverride: false,
+  theirDefaultName: 'Counsellor',
+};
+
+const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {
+  switch (helpline) {
+    default:
+      return defaultLanguage;
   }
-  
-  const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {
-    switch (helpline) {
-      default:
-        return defaultLanguage;
-    }
-  };
-  
-  export const config: Configuration = {
-    accountSid,
-    flexFlowSid,
-    defaultLanguage,
-    translations,
-    preEngagementConfig,
-    closedHours,
-    holidayHours,
-    checkOpenHours,
-    mapHelplineLanguage,
-    memberDisplayOptions,
-    captureIp,
-    contactType
-  };
-  
+};
+
+export const config: Configuration = {
+  accountSid,
+  flexFlowSid,
+  defaultLanguage,
+  translations,
+  preEngagementConfig,
+  closedHours,
+  holidayHours,
+  checkOpenHours,
+  mapHelplineLanguage,
+  memberDisplayOptions,
+  captureIp,
+  contactType,
+};

--- a/configurations/uk-staging.ts
+++ b/configurations/uk-staging.ts
@@ -14,16 +14,16 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import {PreEngagementConfig,Translations,Configuration,MapHelplineLanguage, ContactType} from '../types'
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
 
 const accountSid = 'AC542ee9a6613ce5ff976d075a3e3bd38d';
 const flexFlowSid = 'FOfe2df2f82dd40be24d41347fff7c6f1c';
-const defaultLanguage ='en-GB';
+const defaultLanguage = 'en-GB';
 const captureIp = true;
 const contactType: ContactType = 'ip';
 
 const preEngagementConfig: PreEngagementConfig = {
-  description: "Welcome to the Revenge Porn and Report Harmful Content Helplines.",
+  description: 'Welcome to the Revenge Porn and Report Harmful Content Helplines.',
   fields: [
     {
       label: 'Select the service',
@@ -43,7 +43,7 @@ const preEngagementConfig: PreEngagementConfig = {
           value: 'RHC',
           label: 'Report Harmful Content Helpline',
           selected: false,
-        }
+        },
       ],
     },
   ],
@@ -54,7 +54,7 @@ const translations: Translations = {
   'en-GB': {
     WelcomeMessage: 'Thank you for reaching out.',
     MessageCanvasTrayContent: '',
-    MessageInputDisabledReasonHold: 
+    MessageInputDisabledReasonHold:
       "Thank you very much for this information. We'll transfer you now. Please hold for a practitioner.",
     AutoFirstMessage: 'Incoming webchat contact from',
     TypingIndicator: 'Counselor is typing',
@@ -68,7 +68,7 @@ const memberDisplayOptions = {
   yourFriendlyNameOverride: false,
   theirFriendlyNameOverride: false,
   theirDefaultName: 'Counsellor',
-}
+};
 
 const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {
   switch (helpline) {
@@ -76,8 +76,6 @@ const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {
       return defaultLanguage;
   }
 };
-
-
 
 export const config: Configuration = {
   accountSid,
@@ -87,5 +85,6 @@ export const config: Configuration = {
   preEngagementConfig,
   mapHelplineLanguage,
   memberDisplayOptions,
-  captureIp,contactType,
+  captureIp,
+  contactType,
 };

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -23,7 +23,7 @@ import { Reducer } from 'redux';
 
 import { getUserIp } from './ip-tracker';
 import { displayOperatingHours } from './operating-hours';
-import { updateZIndex } from './dom-utils';
+import { updateZIndex, setExternalWebChatLanguage } from './dom-utils';
 import blockedIps from './blockedIps.json';
 import CloseChatButtons from './end-chat/CloseChatButtons';
 import { getChangeLanguageWebChat } from './language';
@@ -37,6 +37,7 @@ import { config } from './config';
 
 updateZIndex();
 
+// eslint-disable-next-line import/no-unused-modules
 export const getCurrentConfig = (): Configuration => {
   if (!config) {
     throw new Error(`Failed trying to load config file ${webpack.env.CONFIG}`);
@@ -46,6 +47,7 @@ export const getCurrentConfig = (): Configuration => {
 };
 
 const currentConfig = getCurrentConfig();
+const externalWebChatLanguage = setExternalWebChatLanguage();
 
 const { defaultLanguage, translations } = currentConfig;
 const initialLanguage = defaultLanguage;
@@ -138,7 +140,15 @@ export const initWebchat = async () => {
 
   const changeLanguageWebChat = getChangeLanguageWebChat(manager, currentConfig);
 
-  changeLanguageWebChat(initialLanguage);
+  const setChangeLanguageWebChat = (external: string | null | undefined, language: string) => {
+    if (external) {
+      changeLanguageWebChat(external);
+    } else {
+      changeLanguageWebChat(language);
+    }
+  };
+
+  setChangeLanguageWebChat(externalWebChatLanguage, initialLanguage);
 
   // If caller is waiting for a counselor to connect, disable input (default language)
   if (manager.chatClient) {
@@ -174,7 +184,7 @@ export const initWebchat = async () => {
     const { language } = payload.formData;
 
     // Here we collect caller language (from preEngagement select) and change UI language
-    changeLanguageWebChat(language);
+    setChangeLanguageWebChat(externalWebChatLanguage, language);
 
     const channel = await chatChannel(manager);
 

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -176,7 +176,7 @@ export const initWebchat = async () => {
     const { language } = payload.formData;
 
     // Here we collect caller language (from preEngagement select) and change UI language
-    changeLanguageWebChat(externalWebChatLanguage || language);
+    changeLanguageWebChat(language || externalWebChatLanguage);
 
     const channel = await chatChannel(manager);
 

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -23,7 +23,7 @@ import { Reducer } from 'redux';
 
 import { getUserIp } from './ip-tracker';
 import { displayOperatingHours } from './operating-hours';
-import { updateZIndex, setExternalWebChatLanguage } from './dom-utils';
+import { updateZIndex, getWebChatLanguageAttributeValue } from './dom-utils';
 import blockedIps from './blockedIps.json';
 import CloseChatButtons from './end-chat/CloseChatButtons';
 import { getChangeLanguageWebChat } from './language';
@@ -47,7 +47,7 @@ export const getCurrentConfig = (): Configuration => {
 };
 
 const currentConfig = getCurrentConfig();
-const externalWebChatLanguage = setExternalWebChatLanguage();
+const externalWebChatLanguage = getWebChatLanguageAttributeValue();
 
 const { defaultLanguage, translations } = currentConfig;
 const initialLanguage = defaultLanguage;
@@ -140,15 +140,7 @@ export const initWebchat = async () => {
 
   const changeLanguageWebChat = getChangeLanguageWebChat(manager, currentConfig);
 
-  const setChangeLanguageWebChat = (external: string | null | undefined, language: string) => {
-    if (external) {
-      changeLanguageWebChat(external);
-    } else {
-      changeLanguageWebChat(language);
-    }
-  };
-
-  setChangeLanguageWebChat(externalWebChatLanguage, initialLanguage);
+  changeLanguageWebChat(externalWebChatLanguage || initialLanguage);
 
   // If caller is waiting for a counselor to connect, disable input (default language)
   if (manager.chatClient) {
@@ -184,7 +176,7 @@ export const initWebchat = async () => {
     const { language } = payload.formData;
 
     // Here we collect caller language (from preEngagement select) and change UI language
-    setChangeLanguageWebChat(externalWebChatLanguage, language);
+    changeLanguageWebChat(externalWebChatLanguage || language);
 
     const channel = await chatChannel(manager);
 

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -54,6 +54,6 @@ function isHTMLElement(node: Node): node is HTMLElement {
   return node.nodeType === Node.ELEMENT_NODE;
 }
 
-export function setExternalWebChatLanguage() {
+export function getWebChatLanguageAttributeValue() {
   return document?.currentScript?.getAttribute('data-language');
 }

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -53,3 +53,7 @@ export function updateZIndex() {
 function isHTMLElement(node: Node): node is HTMLElement {
   return node.nodeType === Node.ELEMENT_NODE;
 }
+
+export function setExternalWebChatLanguage() {
+  return document?.currentScript?.getAttribute('data-language');
+}

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -14,18 +14,9 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import en from './en';
-import es from './es';
-import fr from './fr';
-import hu from './hu';
-import ru from './ru';
-import ukr from './ukr';
-
+// eslint-disable-next-line global-require, import/no-unused-modules
 export default {
-  en,
-  es,
-  fr,
-  hu,
-  ru,
-  ukr,
-} as Record<string, Record<string, string>>;
+  EndChatButtonLabel: 'Terminer Conversation',
+  QuickExitButtonLabel: 'Sortie Rapide',
+  QuickExitDescription: 'Besoin de Partir Rapidement?',
+} as Record<string, string>;


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
new feature: Web page language detection

### Checklist
- [x] Corresponding issue has been opened
- [N/A] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes CHI-1070

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->

In the `index.html` file, add the `data-language` attribute within the script tag, and set a language as the value. E.g., `data-language="ukr-HU"` save and verify that the web chat is set to the correct translation.

The [Aselo Webchat Integration](https://app.box.com/notes/850639952620?s=y9qf67jmj5pfqhczgd72g58yt3uf3qxt) document was updated to reflect the changes. 
