### PR TITLE
translate pre-engagement form

### DIFF
--- a/configurations/as-development.ts
+++ b/configurations/as-development.ts
@@ -20,7 +20,6 @@ import type {
   Configuration,
   MapHelplineLanguage,
   LocalizedFormAttributes,
-  FormAttribute,
 } from '../types';
 
 const accountSid = 'ACd8a2e89748318adf6ddff7df6948deaf';
@@ -30,7 +29,6 @@ const captureIp = true;
 const checkOpenHours = true;
 const contactType = 'ip';
 const showEmojiPicker = true;
-const fakeHelpline = 'Fake Helpline';
 
 const translations: Translations = {
   'en-US': {
@@ -38,7 +36,6 @@ const translations: Translations = {
     MessageCanvasTrayContent: '',
     MessageInputDisabledReasonHold: 'Please hold for a counselor.',
     AutoFirstMessage: 'Incoming webchat contact from',
-    description: "Let's get started",
   },
   es: {
     EntryPointTagline: 'Chatea con nosotros',
@@ -71,32 +68,34 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: translations['en-US'].description,
-  fields: [
-    {
-      label: 'What is your helpline?',
-      type: 'SelectItem',
-      attributes: {
-        name: 'helpline',
-        required: true,
-        readOnly: false,
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-US': {
+    description: "Let's get started",
+    fields: [
+      {
+        label: 'What is your helpline?',
+        type: 'SelectItem',
+        attributes: {
+          name: 'helpline',
+          required: true,
+          readOnly: false,
+        },
+        options: [
+          {
+            value: 'Select helpline',
+            label: 'Select helpline',
+            selected: true,
+          },
+          {
+            value: 'Fake Helpline',
+            label: 'Fake Helpline',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: 'Select helpline',
-          label: 'Select helpline',
-          selected: true,
-        },
-        {
-          value: fakeHelpline,
-          label: fakeHelpline,
-          selected: false,
-        },
-      ],
-    },
-  ],
-  submitLabel: "Let's chat!",
+    ],
+    submitLabel: "Let's chat",
+  },
 };
 
 const closedHours: PreEngagementConfig = {

--- a/configurations/as-development.ts
+++ b/configurations/as-development.ts
@@ -14,7 +14,13 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import type { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage } from '../types';
+import type {
+  PreEngagementConfig,
+  Translations,
+  Configuration,
+  MapHelplineLanguage,
+  LocalizedFormAttributes,
+} from '../types';
 
 const accountSid = 'ACd8a2e89748318adf6ddff7df6948deaf';
 const flexFlowSid = 'FO8c2d9c388e7feba8b08d06a4bc3f69d1';
@@ -62,32 +68,34 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: "Let's get started",
-  fields: [
-    {
-      label: 'What is your helpline?',
-      type: 'SelectItem',
-      attributes: {
-        name: 'helpline',
-        required: true,
-        readOnly: false,
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-US': {
+    description: "Let's get started",
+    fields: [
+      {
+        label: 'What is your helpline?',
+        type: 'SelectItem',
+        attributes: {
+          name: 'helpline',
+          required: true,
+          readOnly: false,
+        },
+        options: [
+          {
+            value: 'Select helpline',
+            label: 'Select helpline',
+            selected: true,
+          },
+          {
+            value: 'Fake Helpline',
+            label: 'Fake Helpline',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: 'Select helpline',
-          label: 'Select helpline',
-          selected: true,
-        },
-        {
-          value: 'Fake Helpline',
-          label: 'Fake Helpline',
-          selected: false,
-        },
-      ],
-    },
-  ],
-  submitLabel: "Let's chat!",
+    ],
+    submitLabel: "Let's chat!",
+  },
 };
 
 const closedHours: PreEngagementConfig = {

--- a/configurations/as-development.ts
+++ b/configurations/as-development.ts
@@ -29,6 +29,7 @@ const captureIp = true;
 const checkOpenHours = true;
 const contactType = 'ip';
 const showEmojiPicker = true;
+const fakeHelpline = 'Fake Helpline';
 
 const translations: Translations = {
   'en-US': {
@@ -87,8 +88,8 @@ const preEngagementConfig: LocalizedFormAttributes = {
             selected: true,
           },
           {
-            value: 'Fake Helpline',
-            label: 'Fake Helpline',
+            value: fakeHelpline,
+            label: fakeHelpline,
             selected: false,
           },
         ],

--- a/configurations/as-development.ts
+++ b/configurations/as-development.ts
@@ -20,6 +20,7 @@ import type {
   Configuration,
   MapHelplineLanguage,
   LocalizedFormAttributes,
+  FormAttribute,
 } from '../types';
 
 const accountSid = 'ACd8a2e89748318adf6ddff7df6948deaf';
@@ -37,6 +38,7 @@ const translations: Translations = {
     MessageCanvasTrayContent: '',
     MessageInputDisabledReasonHold: 'Please hold for a counselor.',
     AutoFirstMessage: 'Incoming webchat contact from',
+    description: "Let's get started",
   },
   es: {
     EntryPointTagline: 'Chatea con nosotros',
@@ -69,34 +71,32 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: LocalizedFormAttributes = {
-  'en-US': {
-    description: "Let's get started",
-    fields: [
-      {
-        label: 'What is your helpline?',
-        type: 'SelectItem',
-        attributes: {
-          name: 'helpline',
-          required: true,
-          readOnly: false,
-        },
-        options: [
-          {
-            value: 'Select helpline',
-            label: 'Select helpline',
-            selected: true,
-          },
-          {
-            value: fakeHelpline,
-            label: fakeHelpline,
-            selected: false,
-          },
-        ],
+const preEngagementConfig: PreEngagementConfig = {
+  description: translations['en-US'].description,
+  fields: [
+    {
+      label: 'What is your helpline?',
+      type: 'SelectItem',
+      attributes: {
+        name: 'helpline',
+        required: true,
+        readOnly: false,
       },
-    ],
-    submitLabel: "Let's chat!",
-  },
+      options: [
+        {
+          value: 'Select helpline',
+          label: 'Select helpline',
+          selected: true,
+        },
+        {
+          value: fakeHelpline,
+          label: fakeHelpline,
+          selected: false,
+        },
+      ],
+    },
+  ],
+  submitLabel: "Let's chat!",
 };
 
 const closedHours: PreEngagementConfig = {

--- a/configurations/as-staging.ts
+++ b/configurations/as-staging.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
+import { Translations, Configuration, MapHelplineLanguage, ContactType, LocalizedFormAttributes } from '../types';
 
 const accountSid = 'AC6b99858a6faf7af1b572c83988b50eb1';
 const flexFlowSid = 'FO57c22d5dfc7a18dcada507aa70ca0cb3';
@@ -23,149 +23,152 @@ const captureIp = true;
 const contactType: ContactType = 'ip';
 
 const translations: Translations = {
-  'ar': {
+  ar: {
     MessageCanvasTrayContent: '',
     AutoFirstMessage: '',
   },
-  'el': {
+  el: {
     MessageCanvasTrayContent: '',
     AutoFirstMessage: '',
   },
   'en-US': {
-    WelcomeMessage: "Welcome to Aselo!",
+    WelcomeMessage: 'Welcome to Aselo!',
     MessageCanvasTrayContent: '',
-    MessageInputDisabledReasonHold: "Please hold for a counsellor.",
-    AutoFirstMessage: "Incoming webchat contact from",
+    MessageInputDisabledReasonHold: 'Please hold for a counsellor.',
+    AutoFirstMessage: 'Incoming webchat contact from',
   },
-  'es': {
-    EntryPointTagline: "Chatea con nosotros",
-    MessageCanvasTrayButton: "EMPEZAR NUEVO CHAT",
-    InvalidPreEngagementMessage: "Los formularios previos al compromiso no se han establecido y son necesarios para iniciar el chat web. Por favor configúrelos ahora en la configuración.",
-    InvalidPreEngagementButton: "Aprende más",
-    PredefinedChatMessageAuthorName: "Bot",
-    PredefinedChatMessageBody: "¡Hola! ¿Cómo podemos ayudarte hoy?",
-    InputPlaceHolder: "Escribe un mensaje",
-    TypingIndicator: "{0} está escribiendo ... ",
-    Read: "Visto",
-    MessageSendingDisabled: "El envío de mensajes ha sido desactivado",
-    Today: "HOY",
-    Yesterday: "AYER",
-    Save: "GUARDAR",
-    Reset: "RESETEAR",
-    MessageCharacterCountStatus: "{{currentCharCount}} / {{maxCharCount}}",
-    SendMessageTooltip: "Enviar Mensaje",
-    FieldValidationRequiredField: "Campo requerido",
-    FieldValidationInvalidEmail: "Por favor provea una dirección válida de email",
+  es: {
+    EntryPointTagline: 'Chatea con nosotros',
+    MessageCanvasTrayButton: 'EMPEZAR NUEVO CHAT',
+    InvalidPreEngagementMessage:
+      'Los formularios previos al compromiso no se han establecido y son necesarios para iniciar el chat web. Por favor configúrelos ahora en la configuración.',
+    InvalidPreEngagementButton: 'Aprende más',
+    PredefinedChatMessageAuthorName: 'Bot',
+    PredefinedChatMessageBody: '¡Hola! ¿Cómo podemos ayudarte hoy?',
+    InputPlaceHolder: 'Escribe un mensaje',
+    TypingIndicator: '{0} está escribiendo ... ',
+    Read: 'Visto',
+    MessageSendingDisabled: 'El envío de mensajes ha sido desactivado',
+    Today: 'HOY',
+    Yesterday: 'AYER',
+    Save: 'GUARDAR',
+    Reset: 'RESETEAR',
+    MessageCharacterCountStatus: '{{currentCharCount}} / {{maxCharCount}}',
+    SendMessageTooltip: 'Enviar Mensaje',
+    FieldValidationRequiredField: 'Campo requerido',
+    FieldValidationInvalidEmail: 'Por favor provea una dirección válida de email',
 
-    PreEngagementDescription: "Comencemos",
+    PreEngagementDescription: 'Comencemos',
 
-    BotGreeting: "¿Cómo puedo ayudar?",
-    WelcomeMessage: "¡Bienvenido a Aselo!",
+    BotGreeting: '¿Cómo puedo ayudar?',
+    WelcomeMessage: '¡Bienvenido a Aselo!',
     MessageCanvasTrayContent: '',
     AutoFirstMessage: '',
   },
-  'da': {
+  da: {
     MessageCanvasTrayContent: '',
     AutoFirstMessage: '',
   },
-  'it': {
+  it: {
     MessageCanvasTrayContent: '',
     AutoFirstMessage: '',
   },
-  'km': {
+  km: {
     MessageCanvasTrayContent: '',
     AutoFirstMessage: '',
   },
-  'sv': {
+  sv: {
     MessageCanvasTrayContent: '',
     AutoFirstMessage: '',
-  }
+  },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: "Let's get started",
-  fields:
-    [{
-      label: "What is your helpline?",
-      type: "SelectItem",
-      attributes: {
-        name: "helpline",
-        required: true,
-        readOnly: false
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-US': {
+    description: "Let's get started",
+    fields: [
+      {
+        label: 'What is your helpline?',
+        type: 'SelectItem',
+        attributes: {
+          name: 'helpline',
+          required: true,
+          readOnly: false,
+        },
+        options: [
+          {
+            value: 'Select helpline',
+            label: 'Select helpline',
+            selected: true,
+          },
+          {
+            value: 'Børns Vilkår (DK)',
+            label: 'Børns Vilkår (DK)',
+            selected: false,
+          },
+          {
+            value: 'Childhelp (US)',
+            label: 'Childhelp (US)',
+            selected: false,
+          },
+          {
+            value: 'CHILDLINE India (IN)',
+            label: 'CHILDLINE India (IN)',
+            selected: false,
+          },
+          {
+            value: 'Childline South Africa (SA)',
+            label: 'Childline South Africa (SA)',
+            selected: false,
+          },
+          {
+            value: 'ChildLine Zambia (ZM)',
+            label: 'ChildLine Zambia (ZM)',
+            selected: false,
+          },
+          {
+            value: 'Child Helpline Cambodia (KH)',
+            label: 'Child Helpline Cambodia (KH)',
+            selected: false,
+          },
+          {
+            value: 'Jordan River 110 (JO)',
+            label: 'Jordan River 110 (JO)',
+            selected: false,
+          },
+          {
+            value: 'SMILE OF THE CHILD (GR)',
+            label: 'SMILE OF THE CHILD (GR)',
+            selected: false,
+          },
+          {
+            value: 'Telefono Azzurro (IT)',
+            label: 'Telefono Azzurro (IT)',
+            selected: false,
+          },
+          {
+            value: 'BRIS (SE)',
+            label: 'BRIS (SE)',
+            selected: false,
+          },
+          {
+            value: '2NDFLOOR (US)',
+            label: '2NDFLOOR (US)',
+            selected: false,
+          },
+          {
+            value: 'Palo Alto Testing (Text)',
+            label: 'Palo Alto Testing (Text)',
+            selected: false,
+          },
+        ],
       },
-      options: 
-      [
-        {
-          value: "Select helpline",
-          label: "Select helpline",
-          selected: true
-        },
-        {
-          value: "Børns Vilkår (DK)",
-          label: "Børns Vilkår (DK)",
-          selected: false
-        },
-        {
-          value: "Childhelp (US)",
-          label: "Childhelp (US)",
-          selected: false
-        },
-        {
-          value: "CHILDLINE India (IN)",
-          label: "CHILDLINE India (IN)",
-          selected: false
-        },
-        {
-          value: "Childline South Africa (SA)",
-          label: "Childline South Africa (SA)",
-          selected: false
-        },
-        {
-          value: "ChildLine Zambia (ZM)",
-          label: "ChildLine Zambia (ZM)",
-          selected: false
-        },
-        {
-          value: "Child Helpline Cambodia (KH)",
-          label: "Child Helpline Cambodia (KH)",
-          selected: false
-        },
-        {
-          value: "Jordan River 110 (JO)",
-          label: "Jordan River 110 (JO)",
-          selected: false
-        },
-        {
-          value: "SMILE OF THE CHILD (GR)",
-          label: "SMILE OF THE CHILD (GR)",
-          selected: false
-        },
-        {
-          value: "Telefono Azzurro (IT)",
-          label: "Telefono Azzurro (IT)",
-          selected: false
-        },
-        {
-          value: "BRIS (SE)",
-          label: "BRIS (SE)",
-          selected: false
-        },
-        {
-          value: "2NDFLOOR (US)",
-          label: "2NDFLOOR (US)",
-          selected: false
-        },
-        {
-          value: "Palo Alto Testing (Text)",
-          label: "Palo Alto Testing (Text)",
-          selected: false
-        }
-      ]
-    }],
-  submitLabel: "Let's chat!"
+    ],
+    submitLabel: "Let's chat!",
+  },
 };
 
-const mapHelplineLanguage: MapHelplineLanguage = helpline => {
+const mapHelplineLanguage: MapHelplineLanguage = (helpline: string) => {
   switch (helpline) {
     case 'Børns Vilkår (DK)':
       return 'da';
@@ -184,7 +187,7 @@ const mapHelplineLanguage: MapHelplineLanguage = helpline => {
     default:
       return defaultLanguage;
   }
-}
+};
 
 export const config: Configuration = {
   accountSid,
@@ -194,5 +197,5 @@ export const config: Configuration = {
   preEngagementConfig,
   mapHelplineLanguage,
   captureIp,
-  contactType
+  contactType,
 };

--- a/configurations/as-staging.ts
+++ b/configurations/as-staging.ts
@@ -14,7 +14,14 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
+import {
+  PreEngagementConfig,
+  Translations,
+  Configuration,
+  MapHelplineLanguage,
+  ContactType,
+  LocalizedFormAttributes,
+} from '../types';
 
 const accountSid = 'AC6b99858a6faf7af1b572c83988b50eb1';
 const flexFlowSid = 'FO57c22d5dfc7a18dcada507aa70ca0cb3';
@@ -83,87 +90,89 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: "Let's get started",
-  fields: [
-    {
-      label: 'What is your helpline?',
-      type: 'SelectItem',
-      attributes: {
-        name: 'helpline',
-        required: true,
-        readOnly: false,
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-US': {
+    description: "Let's get started",
+    fields: [
+      {
+        label: 'What is your helpline?',
+        type: 'SelectItem',
+        attributes: {
+          name: 'helpline',
+          required: true,
+          readOnly: false,
+        },
+        options: [
+          {
+            value: 'Select helpline',
+            label: 'Select helpline',
+            selected: true,
+          },
+          {
+            value: 'Børns Vilkår (DK)',
+            label: 'Børns Vilkår (DK)',
+            selected: false,
+          },
+          {
+            value: 'Childhelp (US)',
+            label: 'Childhelp (US)',
+            selected: false,
+          },
+          {
+            value: 'CHILDLINE India (IN)',
+            label: 'CHILDLINE India (IN)',
+            selected: false,
+          },
+          {
+            value: 'Childline South Africa (SA)',
+            label: 'Childline South Africa (SA)',
+            selected: false,
+          },
+          {
+            value: 'ChildLine Zambia (ZM)',
+            label: 'ChildLine Zambia (ZM)',
+            selected: false,
+          },
+          {
+            value: 'Child Helpline Cambodia (KH)',
+            label: 'Child Helpline Cambodia (KH)',
+            selected: false,
+          },
+          {
+            value: 'Jordan River 110 (JO)',
+            label: 'Jordan River 110 (JO)',
+            selected: false,
+          },
+          {
+            value: 'SMILE OF THE CHILD (GR)',
+            label: 'SMILE OF THE CHILD (GR)',
+            selected: false,
+          },
+          {
+            value: 'Telefono Azzurro (IT)',
+            label: 'Telefono Azzurro (IT)',
+            selected: false,
+          },
+          {
+            value: 'BRIS (SE)',
+            label: 'BRIS (SE)',
+            selected: false,
+          },
+          {
+            value: '2NDFLOOR (US)',
+            label: '2NDFLOOR (US)',
+            selected: false,
+          },
+          {
+            value: 'Palo Alto Testing (Text)',
+            label: 'Palo Alto Testing (Text)',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: 'Select helpline',
-          label: 'Select helpline',
-          selected: true,
-        },
-        {
-          value: 'Børns Vilkår (DK)',
-          label: 'Børns Vilkår (DK)',
-          selected: false,
-        },
-        {
-          value: 'Childhelp (US)',
-          label: 'Childhelp (US)',
-          selected: false,
-        },
-        {
-          value: 'CHILDLINE India (IN)',
-          label: 'CHILDLINE India (IN)',
-          selected: false,
-        },
-        {
-          value: 'Childline South Africa (SA)',
-          label: 'Childline South Africa (SA)',
-          selected: false,
-        },
-        {
-          value: 'ChildLine Zambia (ZM)',
-          label: 'ChildLine Zambia (ZM)',
-          selected: false,
-        },
-        {
-          value: 'Child Helpline Cambodia (KH)',
-          label: 'Child Helpline Cambodia (KH)',
-          selected: false,
-        },
-        {
-          value: 'Jordan River 110 (JO)',
-          label: 'Jordan River 110 (JO)',
-          selected: false,
-        },
-        {
-          value: 'SMILE OF THE CHILD (GR)',
-          label: 'SMILE OF THE CHILD (GR)',
-          selected: false,
-        },
-        {
-          value: 'Telefono Azzurro (IT)',
-          label: 'Telefono Azzurro (IT)',
-          selected: false,
-        },
-        {
-          value: 'BRIS (SE)',
-          label: 'BRIS (SE)',
-          selected: false,
-        },
-        {
-          value: '2NDFLOOR (US)',
-          label: '2NDFLOOR (US)',
-          selected: false,
-        },
-        {
-          value: 'Palo Alto Testing (Text)',
-          label: 'Palo Alto Testing (Text)',
-          selected: false,
-        },
-      ],
-    },
-  ],
-  submitLabel: "Let's chat!",
+    ],
+    submitLabel: "Let's chat!",
+  },
 };
 
 const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {

--- a/configurations/as-staging.ts
+++ b/configurations/as-staging.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { Translations, Configuration, MapHelplineLanguage, ContactType, LocalizedFormAttributes } from '../types';
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
 
 const accountSid = 'AC6b99858a6faf7af1b572c83988b50eb1';
 const flexFlowSid = 'FO57c22d5dfc7a18dcada507aa70ca0cb3';
@@ -83,92 +83,90 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: LocalizedFormAttributes = {
-  'en-US': {
-    description: "Let's get started",
-    fields: [
-      {
-        label: 'What is your helpline?',
-        type: 'SelectItem',
-        attributes: {
-          name: 'helpline',
-          required: true,
-          readOnly: false,
-        },
-        options: [
-          {
-            value: 'Select helpline',
-            label: 'Select helpline',
-            selected: true,
-          },
-          {
-            value: 'Børns Vilkår (DK)',
-            label: 'Børns Vilkår (DK)',
-            selected: false,
-          },
-          {
-            value: 'Childhelp (US)',
-            label: 'Childhelp (US)',
-            selected: false,
-          },
-          {
-            value: 'CHILDLINE India (IN)',
-            label: 'CHILDLINE India (IN)',
-            selected: false,
-          },
-          {
-            value: 'Childline South Africa (SA)',
-            label: 'Childline South Africa (SA)',
-            selected: false,
-          },
-          {
-            value: 'ChildLine Zambia (ZM)',
-            label: 'ChildLine Zambia (ZM)',
-            selected: false,
-          },
-          {
-            value: 'Child Helpline Cambodia (KH)',
-            label: 'Child Helpline Cambodia (KH)',
-            selected: false,
-          },
-          {
-            value: 'Jordan River 110 (JO)',
-            label: 'Jordan River 110 (JO)',
-            selected: false,
-          },
-          {
-            value: 'SMILE OF THE CHILD (GR)',
-            label: 'SMILE OF THE CHILD (GR)',
-            selected: false,
-          },
-          {
-            value: 'Telefono Azzurro (IT)',
-            label: 'Telefono Azzurro (IT)',
-            selected: false,
-          },
-          {
-            value: 'BRIS (SE)',
-            label: 'BRIS (SE)',
-            selected: false,
-          },
-          {
-            value: '2NDFLOOR (US)',
-            label: '2NDFLOOR (US)',
-            selected: false,
-          },
-          {
-            value: 'Palo Alto Testing (Text)',
-            label: 'Palo Alto Testing (Text)',
-            selected: false,
-          },
-        ],
+const preEngagementConfig: PreEngagementConfig = {
+  description: "Let's get started",
+  fields: [
+    {
+      label: 'What is your helpline?',
+      type: 'SelectItem',
+      attributes: {
+        name: 'helpline',
+        required: true,
+        readOnly: false,
       },
-    ],
-    submitLabel: "Let's chat!",
-  },
+      options: [
+        {
+          value: 'Select helpline',
+          label: 'Select helpline',
+          selected: true,
+        },
+        {
+          value: 'Børns Vilkår (DK)',
+          label: 'Børns Vilkår (DK)',
+          selected: false,
+        },
+        {
+          value: 'Childhelp (US)',
+          label: 'Childhelp (US)',
+          selected: false,
+        },
+        {
+          value: 'CHILDLINE India (IN)',
+          label: 'CHILDLINE India (IN)',
+          selected: false,
+        },
+        {
+          value: 'Childline South Africa (SA)',
+          label: 'Childline South Africa (SA)',
+          selected: false,
+        },
+        {
+          value: 'ChildLine Zambia (ZM)',
+          label: 'ChildLine Zambia (ZM)',
+          selected: false,
+        },
+        {
+          value: 'Child Helpline Cambodia (KH)',
+          label: 'Child Helpline Cambodia (KH)',
+          selected: false,
+        },
+        {
+          value: 'Jordan River 110 (JO)',
+          label: 'Jordan River 110 (JO)',
+          selected: false,
+        },
+        {
+          value: 'SMILE OF THE CHILD (GR)',
+          label: 'SMILE OF THE CHILD (GR)',
+          selected: false,
+        },
+        {
+          value: 'Telefono Azzurro (IT)',
+          label: 'Telefono Azzurro (IT)',
+          selected: false,
+        },
+        {
+          value: 'BRIS (SE)',
+          label: 'BRIS (SE)',
+          selected: false,
+        },
+        {
+          value: '2NDFLOOR (US)',
+          label: '2NDFLOOR (US)',
+          selected: false,
+        },
+        {
+          value: 'Palo Alto Testing (Text)',
+          label: 'Palo Alto Testing (Text)',
+          selected: false,
+        },
+      ],
+    },
+  ],
+  submitLabel: "Let's chat!",
 };
 
-const mapHelplineLanguage: MapHelplineLanguage = (helpline: string) => {
+const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {
   switch (helpline) {
     case 'Børns Vilkår (DK)':
       return 'da';

--- a/configurations/ca-staging.ts
+++ b/configurations/ca-staging.ts
@@ -14,14 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import {
-  PreEngagementConfig,
-  Translations,
-  Configuration,
-  MapHelplineLanguage,
-  ContactType,
-  LocalizedFormAttributes,
-} from '../types';
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
 
 const accountSid = 'ACeb335f4685aa874fddf00cdd7c2946bd';
 const flexFlowSid = 'FO45c6ac308207b8b17bd990eadf5246fe';
@@ -74,1439 +67,720 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: LocalizedFormAttributes = {
-  'en-CA': {
-    description: 'Welcome to Kids Help Phone. To help us serve you better, please answer the following questions.',
-    fields: [
-      {
-        type: 'InputItem',
-        label: 'Nickname (please do not share your real name)',
-        attributes: {
-          name: 'nickname',
-          type: 'text',
-          placeholder: 'Guest',
-          required: true,
-        },
+const preEngagementConfig: PreEngagementConfig = {
+  description: 'Welcome to Kids Help Phone. To help us serve you better, please answer the following questions.',
+  fields: [
+    {
+      type: 'InputItem',
+      label: 'Nickname (please do not share your real name)',
+      attributes: {
+        name: 'nickname',
+        type: 'text',
+        placeholder: 'Guest',
+        required: true,
       },
-      {
-        label: 'How old are you?',
-        type: 'SelectItem',
-        attributes: {
-          name: 'age',
-          required: true,
-          readOnly: false,
-        },
-        options: [
-          {
-            value: '5 or younger',
-            label: '5 or younger',
-            selected: true,
-          },
-          {
-            value: '06',
-            label: '6',
-            selected: false,
-          },
-          {
-            value: '07',
-            label: '7',
-            selected: false,
-          },
-          {
-            value: '08',
-            label: '8',
-            selected: false,
-          },
-          {
-            value: '09',
-            label: '9',
-            selected: false,
-          },
-          {
-            value: '10',
-            label: '10',
-            selected: false,
-          },
-          {
-            value: '11',
-            label: '11',
-            selected: false,
-          },
-          {
-            value: '12',
-            label: '12',
-            selected: false,
-          },
-          {
-            value: '13',
-            label: '13',
-            selected: false,
-          },
-          {
-            value: '14',
-            label: '14',
-            selected: false,
-          },
-          {
-            value: '15',
-            label: '15',
-            selected: false,
-          },
-          {
-            value: '16',
-            label: '16',
-            selected: false,
-          },
-          {
-            value: '17',
-            label: '17',
-            selected: false,
-          },
-          {
-            value: '18',
-            label: '18',
-            selected: false,
-          },
-          {
-            value: '19',
-            label: '19',
-            selected: false,
-          },
-          {
-            value: '20',
-            label: '20',
-            selected: false,
-          },
-          {
-            value: '21',
-            label: '21',
-            selected: false,
-          },
-          {
-            value: '22',
-            label: '22',
-            selected: false,
-          },
-          {
-            value: '23',
-            label: '23',
-            selected: false,
-          },
-          {
-            value: '24',
-            label: '24',
-            selected: false,
-          },
-          {
-            value: '25',
-            label: '25',
-            selected: false,
-          },
-          {
-            value: '26',
-            label: '26',
-            selected: false,
-          },
-          {
-            value: '27',
-            label: '27',
-            selected: false,
-          },
-          {
-            value: '28',
-            label: '28',
-            selected: false,
-          },
-          {
-            value: '29',
-            label: '29',
-            selected: false,
-          },
-          {
-            value: '>30',
-            label: '>30',
-            selected: false,
-          },
-          {
-            value: 'Unknown',
-            label: 'Prefer not to answer',
-            selected: false,
-          },
-        ],
+    },
+    {
+      label: 'How old are you?',
+      type: 'SelectItem',
+      attributes: {
+        name: 'age',
+        required: true,
+        readOnly: false,
       },
-      {
-        label: 'Do you consider yourself to be:',
-        type: 'SelectItem',
-        attributes: {
-          name: 'gender',
-          required: true,
-          readOnly: false,
+      options: [
+        {
+          value: '5 or younger',
+          label: '5 or younger',
+          selected: true,
         },
-        options: [
-          {
-            value: 'Agender',
-            label: 'Agender',
-            selected: true,
-          },
-          {
-            value: 'Cis Male/Man',
-            label: 'Cis Male/Man',
-            selected: false,
-          },
-          {
-            value: 'Cis Female/Woman',
-            label: 'Cis Female/Woman',
-            selected: false,
-          },
-          {
-            value: 'Non-Binary/Genderqueer/Gender fluid"',
-            label: 'Non-Binary/Genderqueer/Gender fluid"',
-            selected: false,
-          },
-          {
-            value: 'Two-Spirit',
-            label: 'Two-Spirit',
-            selected: false,
-          },
-          {
-            value: 'Trans Female/Woman',
-            label: 'Trans Female/Woman',
-            selected: false,
-          },
-          {
-            value: 'Trans Male/Man',
-            label: 'Trans Male/Man',
-            selected: false,
-          },
-          {
-            value: 'Other',
-            label: 'Other',
-            selected: false,
-          },
-          {
-            value: 'Unknown',
-            label: 'Prefer not to answer',
-            selected: false,
-          },
-        ],
-      },
-      {
-        label: 'Do you consider yourself to be:',
-        type: 'SelectItem',
-        attributes: {
-          name: 'sexualOrientation',
-          required: true,
-          readOnly: false,
+        {
+          value: '06',
+          label: '6',
+          selected: false,
         },
-        options: [
-          {
-            value: 'Asexual',
-            label: 'Asexual',
-            selected: true,
-          },
-          {
-            value: 'Bisexual or Pansexual',
-            label: 'Bisexual or Pansexual',
-            selected: false,
-          },
-          {
-            value: 'Gay or Lesbian',
-            label: 'Gay or Lesbian',
-            selected: false,
-          },
-          {
-            value: 'Queer',
-            label: 'Queer',
-            selected: false,
-          },
-          {
-            value: 'Heterosexual or Straight',
-            label: 'Heterosexual or Straight',
-            selected: false,
-          },
-          {
-            value: 'Questioning or Unsure',
-            label: 'Questioning or Unsure',
-            selected: false,
-          },
-          {
-            value: 'Other',
-            label: 'Other',
-            selected: false,
-          },
-          {
-            value: 'Unknown',
-            label: 'Prefer not to answer',
-            selected: false,
-          },
-        ],
-      },
-      {
-        label: 'Are you a newcomer (i.e., Arrived in Canada within 5 years or less), recent immigrant, and/or refugee?',
-        type: 'SelectItem',
-        attributes: {
-          name: 'Newcomer',
-          required: true,
+        {
+          value: '07',
+          label: '7',
+          selected: false,
         },
-        options: [
-          {
-            value: 'yes',
-            label: 'Yes',
-            selected: true,
-          },
-          {
-            value: 'no',
-            label: 'No',
-            selected: false,
-          },
-          {
-            value: 'Unknown',
-            label: 'Prefer not to answer',
-            selected: false,
-          },
-        ],
-      },
-      {
-        label: 'What province or territory do you live in? ',
-        type: 'SelectItem',
-        attributes: {
-          name: 'province',
-          required: true,
+        {
+          value: '08',
+          label: '8',
+          selected: false,
         },
-        options: [
-          {
-            value: 'Alberta',
-            label: 'Alberta',
-            selected: true,
-          },
-          {
-            value: 'British Columbia',
-            label: 'British Columbia',
-            selected: false,
-          },
-          {
-            value: 'Inuvialuit',
-            label: 'Inuvialuit',
-            selected: false,
-          },
-          {
-            value: 'Manitoba',
-            label: 'Manitoba',
-            selected: false,
-          },
-          {
-            value: 'New Brunswick',
-            label: 'New Brunswick',
-            selected: false,
-          },
-          {
-            value: 'Newfoundland and Labrador',
-            label: 'Newfoundland and Labrador',
-            selected: false,
-          },
-          {
-            value: 'Northwest Territories',
-            label: 'Northwest Territories',
-            selected: false,
-          },
-          {
-            value: 'Nova Scotia',
-            label: 'Nova Scotia',
-            selected: false,
-          },
-          {
-            value: 'Nunavat',
-            label: 'Nunavat',
-            selected: false,
-          },
-          {
-            value: 'Nunavik',
-            label: 'Nunavik',
-            selected: false,
-          },
-          {
-            value: 'Nunatsiavut',
-            label: 'Nunatsiavut',
-            selected: false,
-          },
-          {
-            value: 'Ontario',
-            label: 'Ontario',
-            selected: false,
-          },
-          {
-            value: 'Prince Edward Island',
-            label: 'Prince Edward Island',
-            selected: false,
-          },
-          {
-            value: 'Québec',
-            label: 'Québec',
-            selected: false,
-          },
-          {
-            value: 'Saskatchewan',
-            label: 'Saskatchewan',
-            selected: false,
-          },
-          {
-            value: 'Yukon',
-            label: 'Yukon',
-            selected: false,
-          },
-          {
-            value: 'Contacting us from outside of Canada',
-            label: 'Contacting us from outside of Canada',
-            selected: false,
-          },
-          {
-            value: 'Did not disclose/Did not ask',
-            label: 'Prefer not to answer',
-            selected: false,
-          },
-        ],
-      },
-      {
-        label: 'Tell us more about where you live…',
-        type: 'SelectItem',
-        attributes: {
-          name: 'region',
-          required: true,
+        {
+          value: '09',
+          label: '9',
+          selected: false,
         },
-        options: [
-          {
-            value: 'Rural area',
-            label: 'Rural area (less than 1,000 people)',
-            selected: true,
-          },
-          {
-            value: 'Small city/town',
-            label: 'Small city/town (approximately 1,000 to 29,999 people)',
-            selected: false,
-          },
-          {
-            value: 'Medium city',
-            label: 'Medium city (approximately 30,000 to 99,999 people)',
-            selected: false,
-          },
-          {
-            value: 'Large city/urban centre',
-            label: 'Large city/urban centre (approximately 100,000 people or more)',
-            selected: false,
-          },
-          {
-            value: 'First Nations reserve',
-            label: 'First Nations reserve',
-            selected: false,
-          },
-          {
-            value: 'Other',
-            label: 'Other',
-            selected: false,
-          },
-          {
-            value: 'Unknown',
-            label: 'Prefer not to answer',
-            selected: false,
-          },
-        ],
-      },
-      {
-        label: 'On a scale of 1 to 7, how upset are you right now?',
-        type: 'SelectItem',
-        attributes: {
-          name: 'upset',
-          required: true,
+        {
+          value: '10',
+          label: '10',
+          selected: false,
         },
-        options: [
-          {
-            value: '1',
-            label: '1 - Not Very',
-            selected: true,
-          },
-          {
-            value: '2',
-            label: '2',
-            selected: false,
-          },
-          {
-            value: '3',
-            label: '3',
-            selected: false,
-          },
-          {
-            value: '4',
-            label: '4',
-            selected: false,
-          },
-          {
-            value: '5',
-            label: '5',
-            selected: false,
-          },
-          {
-            value: '6',
-            label: '6',
-            selected: false,
-          },
-          {
-            value: '7',
-            label: '7 - Very',
-            selected: false,
-          },
-        ],
-      },
-      {
-        label: 'Do you consider yourself to be:',
-        type: 'SelectItem',
-        attributes: {
-          name: 'ethnicity',
-          required: false,
+        {
+          value: '11',
+          label: '11',
+          selected: false,
         },
-        options: [
-          {
-            value: '',
-            label: '',
-            selected: true,
-          },
-          {
-            value: 'Black',
-            label: 'Black (e.g., African, Afro-Caribbean, African Canadian descent)',
-            selected: false,
-          },
-          {
-            value: 'East Asian',
-            label: 'East Asian (e.g., East Asian descent; Korean, Chinese, Japanese, etc.)',
-            selected: false,
-          },
-          {
-            value: 'Indigenous',
-            label: 'Indigenous (To North America',
-            selected: false,
-          },
-          {
-            value: 'First Nations',
-            label: 'First Nations [sub-category of Indigenous (To North America)]',
-            selected: false,
-          },
-          {
-            value: 'Métis',
-            label: 'Métis [sub-category of Indigenous (To North America)]',
-            selected: false,
-          },
-          {
-            value: 'Inuit',
-            label: 'Inuit [sub-category of Indigenous (To North America)]',
-            selected: false,
-          },
-          {
-            value: 'Indigenous (non-specified)',
-            label: 'Indigenous (non-specified) [sub-category of Indigenous (To North America)]',
-            selected: false,
-          },
-          {
-            value: 'Indigenous (Not to North America)',
-            label: 'Indigenous (Not to North America)',
-            selected: false,
-          },
-          {
-            value: 'Latin American',
-            label: 'Latin American (e.g., Latin American, Hispanic descent)',
-            selected: false,
-          },
-          {
-            value: 'Middle Eastern',
-            label:
-              'Middle Eastern (e.g., Arab, Persian, West Asian descent; Egyptian, Iranian, Lebanese, Turkish, etc.)',
-            selected: false,
-          },
-          {
-            value: 'Southeast Asian',
-            label:
-              'Southeast Asian (e.g., Southeast Asian descent; Cambodian, Filipino, Indonesian, Laotian, Vietnamese, etc.)',
-            selected: false,
-          },
-          {
-            value: 'South Asian',
-            label: 'South Asian (e.g., South Asian descent; East Indian, Afghan, Pakistani, Sri Lankan, etc.)',
-            selected: false,
-          },
-          {
-            value: 'White',
-            label: 'White (e.g., European descent)',
-            selected: false,
-          },
-          {
-            value: 'Other',
-            label: 'Other',
-            selected: false,
-          },
-          {
-            value: 'Unknown',
-            label: 'Prefer not to answer',
-            selected: false,
-          },
-        ],
-      },
-      {
-        label: 'We would like to learn more about you and if you are currently a student. Do you attend...?',
-        type: 'SelectItem',
-        attributes: {
-          name: 'school',
-          required: false,
+        {
+          value: '12',
+          label: '12',
+          selected: false,
         },
-        options: [
-          {
-            value: '',
-            label: '',
-            selected: true,
-          },
-          {
-            value: 'Elementary School',
-            label: 'Elementary School',
-            selected: false,
-          },
-          {
-            value: 'Middle school/Junior High',
-            label: 'Middle school/Junior High',
-            selected: false,
-          },
-          {
-            value: 'High School',
-            label: 'High School',
-            selected: false,
-          },
-          {
-            value: 'Alternative Education School/Program',
-            label: 'Alternative Education School/Program',
-            selected: false,
-          },
-          {
-            value: 'College',
-            label: 'College',
-            selected: false,
-          },
-          {
-            value: 'University',
-            label: 'University',
-            selected: false,
-          },
-          {
-            value: 'Home School',
-            label: 'Home School',
-            selected: false,
-          },
-          {
-            value: 'Other',
-            label: 'Other',
-            selected: false,
-          },
-          {
-            value: 'Not a student',
-            label: 'Not a student',
-            selected: false,
-          },
-          {
-            value: 'Unknown',
-            label: 'Prefer not to answer',
-            selected: false,
-          },
-        ],
-      },
-      {
-        label: 'Which of these best describes your current living situation?:',
-        type: 'SelectItem',
-        attributes: {
-          name: 'livingSituation',
-          required: false,
+        {
+          value: '13',
+          label: '13',
+          selected: false,
         },
-        options: [
-          {
-            value: '',
-            label: '',
-            selected: true,
-          },
-          {
-            value: 'Living with family members/guardians',
-            label: 'Living with family members/guardians',
-            selected: false,
-          },
-          {
-            value: 'Member of a military family',
-            label: 'Member of a military family',
-            selected: false,
-          },
-          {
-            value: 'Living independently/with peers',
-            label: 'Living independently/with peers',
-            selected: false,
-          },
-          {
-            value: 'Living in a School residence',
-            label: 'Living in a School residence',
-            selected: false,
-          },
-          {
-            value: 'In hospital',
-            label: 'In hospital',
-            selected: false,
-          },
-          {
-            value: 'Treatment centre',
-            label: 'Treatment centre',
-            selected: false,
-          },
-          {
-            value: 'Recovery home',
-            label: 'Recovery home',
-            selected: false,
-          },
-          {
-            value: 'Assisted living centre',
-            label: 'Assisted living centre',
-            selected: false,
-          },
-          {
-            value: 'Homeless',
-            label: 'Homeless (living in a shelter, on the streets or staying with people temporarily)',
-            selected: false,
-          },
-          {
-            value: 'In care',
-            label: 'In care',
-            selected: false,
-          },
-          {
-            value: 'Other',
-            label: 'Other',
-            selected: false,
-          },
-          {
-            value: 'Unknown',
-            label: 'Prefer not to answer',
-            selected: false,
-          },
-        ],
-      },
-    ],
-    submitLabel: 'Start Chat!',
-  },
-  'fr-CA': {
-    description: `Bienvenue à Jeunesse, J'écoute. Pour nous aider à mieux vous servir, veuillez répondre aux questions suivantes.`,
-    fields: [
-      {
-        type: 'InputItem',
-        label: 'Nickname (please do not share your real name)',
-        attributes: {
-          name: 'nickname',
-          type: 'text',
-          placeholder: 'Guest',
-          required: true,
+        {
+          value: '14',
+          label: '14',
+          selected: false,
         },
-      },
-      {
-        label: 'How old are you?',
-        type: 'SelectItem',
-        attributes: {
-          name: 'age',
-          required: true,
-          readOnly: false,
+        {
+          value: '15',
+          label: '15',
+          selected: false,
         },
-        options: [
-          {
-            value: '5 or younger',
-            label: '5 or younger',
-            selected: true,
-          },
-          {
-            value: '06',
-            label: '6',
-            selected: false,
-          },
-          {
-            value: '07',
-            label: '7',
-            selected: false,
-          },
-          {
-            value: '08',
-            label: '8',
-            selected: false,
-          },
-          {
-            value: '09',
-            label: '9',
-            selected: false,
-          },
-          {
-            value: '10',
-            label: '10',
-            selected: false,
-          },
-          {
-            value: '11',
-            label: '11',
-            selected: false,
-          },
-          {
-            value: '12',
-            label: '12',
-            selected: false,
-          },
-          {
-            value: '13',
-            label: '13',
-            selected: false,
-          },
-          {
-            value: '14',
-            label: '14',
-            selected: false,
-          },
-          {
-            value: '15',
-            label: '15',
-            selected: false,
-          },
-          {
-            value: '16',
-            label: '16',
-            selected: false,
-          },
-          {
-            value: '17',
-            label: '17',
-            selected: false,
-          },
-          {
-            value: '18',
-            label: '18',
-            selected: false,
-          },
-          {
-            value: '19',
-            label: '19',
-            selected: false,
-          },
-          {
-            value: '20',
-            label: '20',
-            selected: false,
-          },
-          {
-            value: '21',
-            label: '21',
-            selected: false,
-          },
-          {
-            value: '22',
-            label: '22',
-            selected: false,
-          },
-          {
-            value: '23',
-            label: '23',
-            selected: false,
-          },
-          {
-            value: '24',
-            label: '24',
-            selected: false,
-          },
-          {
-            value: '25',
-            label: '25',
-            selected: false,
-          },
-          {
-            value: '26',
-            label: '26',
-            selected: false,
-          },
-          {
-            value: '27',
-            label: '27',
-            selected: false,
-          },
-          {
-            value: '28',
-            label: '28',
-            selected: false,
-          },
-          {
-            value: '29',
-            label: '29',
-            selected: false,
-          },
-          {
-            value: '>30',
-            label: '>30',
-            selected: false,
-          },
-          {
-            value: 'Unknown',
-            label: 'Prefer not to answer',
-            selected: false,
-          },
-        ],
-      },
-      {
-        label: 'Do you consider yourself to be:',
-        type: 'SelectItem',
-        attributes: {
-          name: 'gender',
-          required: true,
-          readOnly: false,
+        {
+          value: '16',
+          label: '16',
+          selected: false,
         },
-        options: [
-          {
-            value: 'Agender',
-            label: 'Agender',
-            selected: true,
-          },
-          {
-            value: 'Cis Male/Man',
-            label: 'Cis Male/Man',
-            selected: false,
-          },
-          {
-            value: 'Cis Female/Woman',
-            label: 'Cis Female/Woman',
-            selected: false,
-          },
-          {
-            value: 'Non-Binary/Genderqueer/Gender fluid"',
-            label: 'Non-Binary/Genderqueer/Gender fluid"',
-            selected: false,
-          },
-          {
-            value: 'Two-Spirit',
-            label: 'Two-Spirit',
-            selected: false,
-          },
-          {
-            value: 'Trans Female/Woman',
-            label: 'Trans Female/Woman',
-            selected: false,
-          },
-          {
-            value: 'Trans Male/Man',
-            label: 'Trans Male/Man',
-            selected: false,
-          },
-          {
-            value: 'Other',
-            label: 'Other',
-            selected: false,
-          },
-          {
-            value: 'Unknown',
-            label: 'Prefer not to answer',
-            selected: false,
-          },
-        ],
-      },
-      {
-        label: 'Do you consider yourself to be:',
-        type: 'SelectItem',
-        attributes: {
-          name: 'sexualOrientation',
-          required: true,
-          readOnly: false,
+        {
+          value: '17',
+          label: '17',
+          selected: false,
         },
-        options: [
-          {
-            value: 'Asexual',
-            label: 'Asexual',
-            selected: true,
-          },
-          {
-            value: 'Bisexual or Pansexual',
-            label: 'Bisexual or Pansexual',
-            selected: false,
-          },
-          {
-            value: 'Gay or Lesbian',
-            label: 'Gay or Lesbian',
-            selected: false,
-          },
-          {
-            value: 'Queer',
-            label: 'Queer',
-            selected: false,
-          },
-          {
-            value: 'Heterosexual or Straight',
-            label: 'Heterosexual or Straight',
-            selected: false,
-          },
-          {
-            value: 'Questioning or Unsure',
-            label: 'Questioning or Unsure',
-            selected: false,
-          },
-          {
-            value: 'Other',
-            label: 'Other',
-            selected: false,
-          },
-          {
-            value: 'Unknown',
-            label: 'Prefer not to answer',
-            selected: false,
-          },
-        ],
-      },
-      {
-        label: 'Are you a newcomer (i.e., Arrived in Canada within 5 years or less), recent immigrant, and/or refugee?',
-        type: 'SelectItem',
-        attributes: {
-          name: 'Newcomer',
-          required: true,
+        {
+          value: '18',
+          label: '18',
+          selected: false,
         },
-        options: [
-          {
-            value: 'yes',
-            label: 'Yes',
-            selected: true,
-          },
-          {
-            value: 'no',
-            label: 'No',
-            selected: false,
-          },
-          {
-            value: 'Unknown',
-            label: 'Prefer not to answer',
-            selected: false,
-          },
-        ],
-      },
-      {
-        label: 'What province or territory do you live in? ',
-        type: 'SelectItem',
-        attributes: {
-          name: 'province',
-          required: true,
+        {
+          value: '19',
+          label: '19',
+          selected: false,
         },
-        options: [
-          {
-            value: 'Alberta',
-            label: 'Alberta',
-            selected: true,
-          },
-          {
-            value: 'British Columbia',
-            label: 'British Columbia',
-            selected: false,
-          },
-          {
-            value: 'Inuvialuit',
-            label: 'Inuvialuit',
-            selected: false,
-          },
-          {
-            value: 'Manitoba',
-            label: 'Manitoba',
-            selected: false,
-          },
-          {
-            value: 'New Brunswick',
-            label: 'New Brunswick',
-            selected: false,
-          },
-          {
-            value: 'Newfoundland and Labrador',
-            label: 'Newfoundland and Labrador',
-            selected: false,
-          },
-          {
-            value: 'Northwest Territories',
-            label: 'Northwest Territories',
-            selected: false,
-          },
-          {
-            value: 'Nova Scotia',
-            label: 'Nova Scotia',
-            selected: false,
-          },
-          {
-            value: 'Nunavat',
-            label: 'Nunavat',
-            selected: false,
-          },
-          {
-            value: 'Nunavik',
-            label: 'Nunavik',
-            selected: false,
-          },
-          {
-            value: 'Nunatsiavut',
-            label: 'Nunatsiavut',
-            selected: false,
-          },
-          {
-            value: 'Ontario',
-            label: 'Ontario',
-            selected: false,
-          },
-          {
-            value: 'Prince Edward Island',
-            label: 'Prince Edward Island',
-            selected: false,
-          },
-          {
-            value: 'Québec',
-            label: 'Québec',
-            selected: false,
-          },
-          {
-            value: 'Saskatchewan',
-            label: 'Saskatchewan',
-            selected: false,
-          },
-          {
-            value: 'Yukon',
-            label: 'Yukon',
-            selected: false,
-          },
-          {
-            value: 'Contacting us from outside of Canada',
-            label: 'Contacting us from outside of Canada',
-            selected: false,
-          },
-          {
-            value: 'Did not disclose/Did not ask',
-            label: 'Prefer not to answer',
-            selected: false,
-          },
-        ],
-      },
-      {
-        label: 'Tell us more about where you live…',
-        type: 'SelectItem',
-        attributes: {
-          name: 'region',
-          required: true,
+        {
+          value: '20',
+          label: '20',
+          selected: false,
         },
-        options: [
-          {
-            value: 'Rural area',
-            label: 'Rural area (less than 1,000 people)',
-            selected: true,
-          },
-          {
-            value: 'Small city/town',
-            label: 'Small city/town (approximately 1,000 to 29,999 people)',
-            selected: false,
-          },
-          {
-            value: 'Medium city',
-            label: 'Medium city (approximately 30,000 to 99,999 people)',
-            selected: false,
-          },
-          {
-            value: 'Large city/urban centre',
-            label: 'Large city/urban centre (approximately 100,000 people or more)',
-            selected: false,
-          },
-          {
-            value: 'First Nations reserve',
-            label: 'First Nations reserve',
-            selected: false,
-          },
-          {
-            value: 'Other',
-            label: 'Other',
-            selected: false,
-          },
-          {
-            value: 'Unknown',
-            label: 'Prefer not to answer',
-            selected: false,
-          },
-        ],
-      },
-      {
-        label: 'On a scale of 1 to 7, how upset are you right now?',
-        type: 'SelectItem',
-        attributes: {
-          name: 'upset',
-          required: true,
+        {
+          value: '21',
+          label: '21',
+          selected: false,
         },
-        options: [
-          {
-            value: '1',
-            label: '1 - Not Very',
-            selected: true,
-          },
-          {
-            value: '2',
-            label: '2',
-            selected: false,
-          },
-          {
-            value: '3',
-            label: '3',
-            selected: false,
-          },
-          {
-            value: '4',
-            label: '4',
-            selected: false,
-          },
-          {
-            value: '5',
-            label: '5',
-            selected: false,
-          },
-          {
-            value: '6',
-            label: '6',
-            selected: false,
-          },
-          {
-            value: '7',
-            label: '7 - Very',
-            selected: false,
-          },
-        ],
-      },
-      {
-        label: 'Do you consider yourself to be:',
-        type: 'SelectItem',
-        attributes: {
-          name: 'ethnicity',
-          required: false,
+        {
+          value: '22',
+          label: '22',
+          selected: false,
         },
-        options: [
-          {
-            value: '',
-            label: '',
-            selected: true,
-          },
-          {
-            value: 'Black',
-            label: 'Black (e.g., African, Afro-Caribbean, African Canadian descent)',
-            selected: false,
-          },
-          {
-            value: 'East Asian',
-            label: 'East Asian (e.g., East Asian descent; Korean, Chinese, Japanese, etc.)',
-            selected: false,
-          },
-          {
-            value: 'Indigenous',
-            label: 'Indigenous (To North America',
-            selected: false,
-          },
-          {
-            value: 'First Nations',
-            label: 'First Nations [sub-category of Indigenous (To North America)]',
-            selected: false,
-          },
-          {
-            value: 'Métis',
-            label: 'Métis [sub-category of Indigenous (To North America)]',
-            selected: false,
-          },
-          {
-            value: 'Inuit',
-            label: 'Inuit [sub-category of Indigenous (To North America)]',
-            selected: false,
-          },
-          {
-            value: 'Indigenous (non-specified)',
-            label: 'Indigenous (non-specified) [sub-category of Indigenous (To North America)]',
-            selected: false,
-          },
-          {
-            value: 'Indigenous (Not to North America)',
-            label: 'Indigenous (Not to North America)',
-            selected: false,
-          },
-          {
-            value: 'Latin American',
-            label: 'Latin American (e.g., Latin American, Hispanic descent)',
-            selected: false,
-          },
-          {
-            value: 'Middle Eastern',
-            label:
-              'Middle Eastern (e.g., Arab, Persian, West Asian descent; Egyptian, Iranian, Lebanese, Turkish, etc.)',
-            selected: false,
-          },
-          {
-            value: 'Southeast Asian',
-            label:
-              'Southeast Asian (e.g., Southeast Asian descent; Cambodian, Filipino, Indonesian, Laotian, Vietnamese, etc.)',
-            selected: false,
-          },
-          {
-            value: 'South Asian',
-            label: 'South Asian (e.g., South Asian descent; East Indian, Afghan, Pakistani, Sri Lankan, etc.)',
-            selected: false,
-          },
-          {
-            value: 'White',
-            label: 'White (e.g., European descent)',
-            selected: false,
-          },
-          {
-            value: 'Other',
-            label: 'Other',
-            selected: false,
-          },
-          {
-            value: 'Unknown',
-            label: 'Prefer not to answer',
-            selected: false,
-          },
-        ],
-      },
-      {
-        label: 'We would like to learn more about you and if you are currently a student. Do you attend...?',
-        type: 'SelectItem',
-        attributes: {
-          name: 'school',
-          required: false,
+        {
+          value: '23',
+          label: '23',
+          selected: false,
         },
-        options: [
-          {
-            value: '',
-            label: '',
-            selected: true,
-          },
-          {
-            value: 'Elementary School',
-            label: 'Elementary School',
-            selected: false,
-          },
-          {
-            value: 'Middle school/Junior High',
-            label: 'Middle school/Junior High',
-            selected: false,
-          },
-          {
-            value: 'High School',
-            label: 'High School',
-            selected: false,
-          },
-          {
-            value: 'Alternative Education School/Program',
-            label: 'Alternative Education School/Program',
-            selected: false,
-          },
-          {
-            value: 'College',
-            label: 'College',
-            selected: false,
-          },
-          {
-            value: 'University',
-            label: 'University',
-            selected: false,
-          },
-          {
-            value: 'Home School',
-            label: 'Home School',
-            selected: false,
-          },
-          {
-            value: 'Other',
-            label: 'Other',
-            selected: false,
-          },
-          {
-            value: 'Not a student',
-            label: 'Not a student',
-            selected: false,
-          },
-          {
-            value: 'Unknown',
-            label: 'Prefer not to answer',
-            selected: false,
-          },
-        ],
-      },
-      {
-        label: 'Which of these best describes your current living situation?:',
-        type: 'SelectItem',
-        attributes: {
-          name: 'livingSituation',
-          required: false,
+        {
+          value: '24',
+          label: '24',
+          selected: false,
         },
-        options: [
-          {
-            value: '',
-            label: '',
-            selected: true,
-          },
-          {
-            value: 'Living with family members/guardians',
-            label: 'Living with family members/guardians',
-            selected: false,
-          },
-          {
-            value: 'Member of a military family',
-            label: 'Member of a military family',
-            selected: false,
-          },
-          {
-            value: 'Living independently/with peers',
-            label: 'Living independently/with peers',
-            selected: false,
-          },
-          {
-            value: 'Living in a School residence',
-            label: 'Living in a School residence',
-            selected: false,
-          },
-          {
-            value: 'In hospital',
-            label: 'In hospital',
-            selected: false,
-          },
-          {
-            value: 'Treatment centre',
-            label: 'Treatment centre',
-            selected: false,
-          },
-          {
-            value: 'Recovery home',
-            label: 'Recovery home',
-            selected: false,
-          },
-          {
-            value: 'Assisted living centre',
-            label: 'Assisted living centre',
-            selected: false,
-          },
-          {
-            value: 'Homeless',
-            label: 'Homeless (living in a shelter, on the streets or staying with people temporarily)',
-            selected: false,
-          },
-          {
-            value: 'In care',
-            label: 'In care',
-            selected: false,
-          },
-          {
-            value: 'Other',
-            label: 'Other',
-            selected: false,
-          },
-          {
-            value: 'Unknown',
-            label: 'Prefer not to answer',
-            selected: false,
-          },
-        ],
+        {
+          value: '25',
+          label: '25',
+          selected: false,
+        },
+        {
+          value: '26',
+          label: '26',
+          selected: false,
+        },
+        {
+          value: '27',
+          label: '27',
+          selected: false,
+        },
+        {
+          value: '28',
+          label: '28',
+          selected: false,
+        },
+        {
+          value: '29',
+          label: '29',
+          selected: false,
+        },
+        {
+          value: '>30',
+          label: '>30',
+          selected: false,
+        },
+        {
+          value: 'Unknown',
+          label: 'Prefer not to answer',
+          selected: false,
+        },
+      ],
+    },
+    {
+      label: 'Do you consider yourself to be:',
+      type: 'SelectItem',
+      attributes: {
+        name: 'gender',
+        required: true,
+        readOnly: false,
       },
-    ],
-    submitLabel: 'Start Chat!',
-  },
+      options: [
+        {
+          value: 'Agender',
+          label: 'Agender',
+          selected: true,
+        },
+        {
+          value: 'Cis Male/Man',
+          label: 'Cis Male/Man',
+          selected: false,
+        },
+        {
+          value: 'Cis Female/Woman',
+          label: 'Cis Female/Woman',
+          selected: false,
+        },
+        {
+          value: 'Non-Binary/Genderqueer/Gender fluid"',
+          label: 'Non-Binary/Genderqueer/Gender fluid"',
+          selected: false,
+        },
+        {
+          value: 'Two-Spirit',
+          label: 'Two-Spirit',
+          selected: false,
+        },
+        {
+          value: 'Trans Female/Woman',
+          label: 'Trans Female/Woman',
+          selected: false,
+        },
+        {
+          value: 'Trans Male/Man',
+          label: 'Trans Male/Man',
+          selected: false,
+        },
+        {
+          value: 'Other',
+          label: 'Other',
+          selected: false,
+        },
+        {
+          value: 'Unknown',
+          label: 'Prefer not to answer',
+          selected: false,
+        },
+      ],
+    },
+    {
+      label: 'Do you consider yourself to be:',
+      type: 'SelectItem',
+      attributes: {
+        name: 'sexualOrientation',
+        required: true,
+        readOnly: false,
+      },
+      options: [
+        {
+          value: 'Asexual',
+          label: 'Asexual',
+          selected: true,
+        },
+        {
+          value: 'Bisexual or Pansexual',
+          label: 'Bisexual or Pansexual',
+          selected: false,
+        },
+        {
+          value: 'Gay or Lesbian',
+          label: 'Gay or Lesbian',
+          selected: false,
+        },
+        {
+          value: 'Queer',
+          label: 'Queer',
+          selected: false,
+        },
+        {
+          value: 'Heterosexual or Straight',
+          label: 'Heterosexual or Straight',
+          selected: false,
+        },
+        {
+          value: 'Questioning or Unsure',
+          label: 'Questioning or Unsure',
+          selected: false,
+        },
+        {
+          value: 'Other',
+          label: 'Other',
+          selected: false,
+        },
+        {
+          value: 'Unknown',
+          label: 'Prefer not to answer',
+          selected: false,
+        },
+      ],
+    },
+    {
+      label: 'Are you a newcomer (i.e., Arrived in Canada within 5 years or less), recent immigrant, and/or refugee?',
+      type: 'SelectItem',
+      attributes: {
+        name: 'Newcomer',
+        required: true,
+      },
+      options: [
+        {
+          value: 'yes',
+          label: 'Yes',
+          selected: true,
+        },
+        {
+          value: 'no',
+          label: 'No',
+          selected: false,
+        },
+        {
+          value: 'Unknown',
+          label: 'Prefer not to answer',
+          selected: false,
+        },
+      ],
+    },
+    {
+      label: 'What province or territory do you live in? ',
+      type: 'SelectItem',
+      attributes: {
+        name: 'province',
+        required: true,
+      },
+      options: [
+        {
+          value: 'Alberta',
+          label: 'Alberta',
+          selected: true,
+        },
+        {
+          value: 'British Columbia',
+          label: 'British Columbia',
+          selected: false,
+        },
+        {
+          value: 'Inuvialuit',
+          label: 'Inuvialuit',
+          selected: false,
+        },
+        {
+          value: 'Manitoba',
+          label: 'Manitoba',
+          selected: false,
+        },
+        {
+          value: 'New Brunswick',
+          label: 'New Brunswick',
+          selected: false,
+        },
+        {
+          value: 'Newfoundland and Labrador',
+          label: 'Newfoundland and Labrador',
+          selected: false,
+        },
+        {
+          value: 'Northwest Territories',
+          label: 'Northwest Territories',
+          selected: false,
+        },
+        {
+          value: 'Nova Scotia',
+          label: 'Nova Scotia',
+          selected: false,
+        },
+        {
+          value: 'Nunavat',
+          label: 'Nunavat',
+          selected: false,
+        },
+        {
+          value: 'Nunavik',
+          label: 'Nunavik',
+          selected: false,
+        },
+        {
+          value: 'Nunatsiavut',
+          label: 'Nunatsiavut',
+          selected: false,
+        },
+        {
+          value: 'Ontario',
+          label: 'Ontario',
+          selected: false,
+        },
+        {
+          value: 'Prince Edward Island',
+          label: 'Prince Edward Island',
+          selected: false,
+        },
+        {
+          value: 'Québec',
+          label: 'Québec',
+          selected: false,
+        },
+        {
+          value: 'Saskatchewan',
+          label: 'Saskatchewan',
+          selected: false,
+        },
+        {
+          value: 'Yukon',
+          label: 'Yukon',
+          selected: false,
+        },
+        {
+          value: 'Contacting us from outside of Canada',
+          label: 'Contacting us from outside of Canada',
+          selected: false,
+        },
+        {
+          value: 'Did not disclose/Did not ask',
+          label: 'Prefer not to answer',
+          selected: false,
+        },
+      ],
+    },
+    {
+      label: 'Tell us more about where you live…',
+      type: 'SelectItem',
+      attributes: {
+        name: 'region',
+        required: true,
+      },
+      options: [
+        {
+          value: 'Rural area',
+          label: 'Rural area (less than 1,000 people)',
+          selected: true,
+        },
+        {
+          value: 'Small city/town',
+          label: 'Small city/town (approximately 1,000 to 29,999 people)',
+          selected: false,
+        },
+        {
+          value: 'Medium city',
+          label: 'Medium city (approximately 30,000 to 99,999 people)',
+          selected: false,
+        },
+        {
+          value: 'Large city/urban centre',
+          label: 'Large city/urban centre (approximately 100,000 people or more)',
+          selected: false,
+        },
+        {
+          value: 'First Nations reserve',
+          label: 'First Nations reserve',
+          selected: false,
+        },
+        {
+          value: 'Other',
+          label: 'Other',
+          selected: false,
+        },
+        {
+          value: 'Unknown',
+          label: 'Prefer not to answer',
+          selected: false,
+        },
+      ],
+    },
+    {
+      label: 'On a scale of 1 to 7, how upset are you right now?',
+      type: 'SelectItem',
+      attributes: {
+        name: 'upset',
+        required: true,
+      },
+      options: [
+        {
+          value: '1',
+          label: '1 - Not Very',
+          selected: true,
+        },
+        {
+          value: '2',
+          label: '2',
+          selected: false,
+        },
+        {
+          value: '3',
+          label: '3',
+          selected: false,
+        },
+        {
+          value: '4',
+          label: '4',
+          selected: false,
+        },
+        {
+          value: '5',
+          label: '5',
+          selected: false,
+        },
+        {
+          value: '6',
+          label: '6',
+          selected: false,
+        },
+        {
+          value: '7',
+          label: '7 - Very',
+          selected: false,
+        },
+      ],
+    },
+    {
+      label: 'Do you consider yourself to be:',
+      type: 'SelectItem',
+      attributes: {
+        name: 'ethnicity',
+        required: false,
+      },
+      options: [
+        {
+          value: '',
+          label: '',
+          selected: true,
+        },
+        {
+          value: 'Black',
+          label: 'Black (e.g., African, Afro-Caribbean, African Canadian descent)',
+          selected: false,
+        },
+        {
+          value: 'East Asian',
+          label: 'East Asian (e.g., East Asian descent; Korean, Chinese, Japanese, etc.)',
+          selected: false,
+        },
+        {
+          value: 'Indigenous',
+          label: 'Indigenous (To North America',
+          selected: false,
+        },
+        {
+          value: 'First Nations',
+          label: 'First Nations [sub-category of Indigenous (To North America)]',
+          selected: false,
+        },
+        {
+          value: 'Métis',
+          label: 'Métis [sub-category of Indigenous (To North America)]',
+          selected: false,
+        },
+        {
+          value: 'Inuit',
+          label: 'Inuit [sub-category of Indigenous (To North America)]',
+          selected: false,
+        },
+        {
+          value: 'Indigenous (non-specified)',
+          label: 'Indigenous (non-specified) [sub-category of Indigenous (To North America)]',
+          selected: false,
+        },
+        {
+          value: 'Indigenous (Not to North America)',
+          label: 'Indigenous (Not to North America)',
+          selected: false,
+        },
+        {
+          value: 'Latin American',
+          label: 'Latin American (e.g., Latin American, Hispanic descent)',
+          selected: false,
+        },
+        {
+          value: 'Middle Eastern',
+          label: 'Middle Eastern (e.g., Arab, Persian, West Asian descent; Egyptian, Iranian, Lebanese, Turkish, etc.)',
+          selected: false,
+        },
+        {
+          value: 'Southeast Asian',
+          label:
+            'Southeast Asian (e.g., Southeast Asian descent; Cambodian, Filipino, Indonesian, Laotian, Vietnamese, etc.)',
+          selected: false,
+        },
+        {
+          value: 'South Asian',
+          label: 'South Asian (e.g., South Asian descent; East Indian, Afghan, Pakistani, Sri Lankan, etc.)',
+          selected: false,
+        },
+        {
+          value: 'White',
+          label: 'White (e.g., European descent)',
+          selected: false,
+        },
+        {
+          value: 'Other',
+          label: 'Other',
+          selected: false,
+        },
+        {
+          value: 'Unknown',
+          label: 'Prefer not to answer',
+          selected: false,
+        },
+      ],
+    },
+    {
+      label: 'We would like to learn more about you and if you are currently a student. Do you attend...?',
+      type: 'SelectItem',
+      attributes: {
+        name: 'school',
+        required: false,
+      },
+      options: [
+        {
+          value: '',
+          label: '',
+          selected: true,
+        },
+        {
+          value: 'Elementary School',
+          label: 'Elementary School',
+          selected: false,
+        },
+        {
+          value: 'Middle school/Junior High',
+          label: 'Middle school/Junior High',
+          selected: false,
+        },
+        {
+          value: 'High School',
+          label: 'High School',
+          selected: false,
+        },
+        {
+          value: 'Alternative Education School/Program',
+          label: 'Alternative Education School/Program',
+          selected: false,
+        },
+        {
+          value: 'College',
+          label: 'College',
+          selected: false,
+        },
+        {
+          value: 'University',
+          label: 'University',
+          selected: false,
+        },
+        {
+          value: 'Home School',
+          label: 'Home School',
+          selected: false,
+        },
+        {
+          value: 'Other',
+          label: 'Other',
+          selected: false,
+        },
+        {
+          value: 'Not a student',
+          label: 'Not a student',
+          selected: false,
+        },
+        {
+          value: 'Unknown',
+          label: 'Prefer not to answer',
+          selected: false,
+        },
+      ],
+    },
+    {
+      label: 'Which of these best describes your current living situation?:',
+      type: 'SelectItem',
+      attributes: {
+        name: 'livingSituation',
+        required: false,
+      },
+      options: [
+        {
+          value: '',
+          label: '',
+          selected: true,
+        },
+        {
+          value: 'Living with family members/guardians',
+          label: 'Living with family members/guardians',
+          selected: false,
+        },
+        {
+          value: 'Member of a military family',
+          label: 'Member of a military family',
+          selected: false,
+        },
+        {
+          value: 'Living independently/with peers',
+          label: 'Living independently/with peers',
+          selected: false,
+        },
+        {
+          value: 'Living in a School residence',
+          label: 'Living in a School residence',
+          selected: false,
+        },
+        {
+          value: 'In hospital',
+          label: 'In hospital',
+          selected: false,
+        },
+        {
+          value: 'Treatment centre',
+          label: 'Treatment centre',
+          selected: false,
+        },
+        {
+          value: 'Recovery home',
+          label: 'Recovery home',
+          selected: false,
+        },
+        {
+          value: 'Assisted living centre',
+          label: 'Assisted living centre',
+          selected: false,
+        },
+        {
+          value: 'Homeless',
+          label: 'Homeless (living in a shelter, on the streets or staying with people temporarily)',
+          selected: false,
+        },
+        {
+          value: 'In care',
+          label: 'In care',
+          selected: false,
+        },
+        {
+          value: 'Other',
+          label: 'Other',
+          selected: false,
+        },
+        {
+          value: 'Unknown',
+          label: 'Prefer not to answer',
+          selected: false,
+        },
+      ],
+    },
+  ],
+  submitLabel: 'Start Chat!',
 };
 
 const closedHours: PreEngagementConfig = {

--- a/configurations/ca-staging.ts
+++ b/configurations/ca-staging.ts
@@ -14,7 +14,14 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
+import {
+  PreEngagementConfig,
+  Translations,
+  Configuration,
+  MapHelplineLanguage,
+  ContactType,
+  LocalizedFormAttributes,
+} from '../types';
 
 const accountSid = 'ACeb335f4685aa874fddf00cdd7c2946bd';
 const flexFlowSid = 'FO45c6ac308207b8b17bd990eadf5246fe';
@@ -43,743 +50,1463 @@ const translations: Translations = {
     MessageInputDisabledReasonHold:
       "Je vous remercie beaucoup pour l'info. Nous allons le transférer maintenant. Veuillez attendre un agent.",
     AutoFirstMessage: 'Nouveau contact de web',
-    TypingIndicator: "{0} est écrit ... ",
+    TypingIndicator: '{0} est écrit ... ',
     StartChat: 'Démarrer la chat!',
-    MessageCanvasTrayButton: "Démarrer une nouvelle chat",
-    EntryPointTagline: "Discute avec nous",
-    InvalidPreEngagementMessage: "Les formulaires de pré-engagement n'ont pas été établis et sont nécessaires pour démarrer le chat Web. Veuillez les configurer maintenant dans les paramètres.",
-    InvalidPreEngagementButton: "Apprendre encore plus",
-    PredefinedChatMessageAuthorName: "Bot",
+    MessageCanvasTrayButton: 'Démarrer une nouvelle chat',
+    EntryPointTagline: 'Discute avec nous',
+    InvalidPreEngagementMessage:
+      "Les formulaires de pré-engagement n'ont pas été établis et sont nécessaires pour démarrer le chat Web. Veuillez les configurer maintenant dans les paramètres.",
+    InvalidPreEngagementButton: 'Apprendre encore plus',
+    PredefinedChatMessageAuthorName: 'Bot',
     PredefinedChatMessageBody: "Salut! Que peut-on faire pour vous aider aujourd'hui?",
-    InputPlaceHolder: "Écrire un message",
-    Read: "Vu",
+    InputPlaceHolder: 'Écrire un message',
+    Read: 'Vu',
     MessageSendingDisabled: "L'envoi de messages a été désactivé",
     Today: "Aujourd'hui",
-    Yesterday: "Hier",
-    Save: "Sauvegarder",
-    Reset: "RÉINITIALISER",
-    MessageCharacterCountStatus: "{{currentCharCount}} / {{maxCharCount}}",
-    SendMessageTooltip: "Envoyer un message",
-    FieldValidationRequiredField: "Champs requis",
-    PreEngagementDescription: "Commençons",
-    BotGreeting: "Comment je peux aider?",
-  }
+    Yesterday: 'Hier',
+    Save: 'Sauvegarder',
+    Reset: 'RÉINITIALISER',
+    MessageCharacterCountStatus: '{{currentCharCount}} / {{maxCharCount}}',
+    SendMessageTooltip: 'Envoyer un message',
+    FieldValidationRequiredField: 'Champs requis',
+    PreEngagementDescription: 'Commençons',
+    BotGreeting: 'Comment je peux aider?',
+  },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: 'Welcome to Kids Help Phone. To help us serve you better, please answer the following questions.',
-  fields: [
-    {
-      type: 'InputItem',
-      label: 'Nickname (please do not share your real name)',
-      attributes: {
-        name: 'nickname',
-        type: 'text',
-        placeholder: 'Guest',
-        required: true,
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-CA': {
+    description: 'Welcome to Kids Help Phone. To help us serve you better, please answer the following questions.',
+    fields: [
+      {
+        type: 'InputItem',
+        label: 'Nickname (please do not share your real name)',
+        attributes: {
+          name: 'nickname',
+          type: 'text',
+          placeholder: 'Guest',
+          required: true,
+        },
       },
-    },
-    {
-      label: 'How old are you?',
-      type: 'SelectItem',
-      attributes: {
-        name: 'age',
-        required: true,
-        readOnly: false,
+      {
+        label: 'How old are you?',
+        type: 'SelectItem',
+        attributes: {
+          name: 'age',
+          required: true,
+          readOnly: false,
+        },
+        options: [
+          {
+            value: '5 or younger',
+            label: '5 or younger',
+            selected: true,
+          },
+          {
+            value: '06',
+            label: '6',
+            selected: false,
+          },
+          {
+            value: '07',
+            label: '7',
+            selected: false,
+          },
+          {
+            value: '08',
+            label: '8',
+            selected: false,
+          },
+          {
+            value: '09',
+            label: '9',
+            selected: false,
+          },
+          {
+            value: '10',
+            label: '10',
+            selected: false,
+          },
+          {
+            value: '11',
+            label: '11',
+            selected: false,
+          },
+          {
+            value: '12',
+            label: '12',
+            selected: false,
+          },
+          {
+            value: '13',
+            label: '13',
+            selected: false,
+          },
+          {
+            value: '14',
+            label: '14',
+            selected: false,
+          },
+          {
+            value: '15',
+            label: '15',
+            selected: false,
+          },
+          {
+            value: '16',
+            label: '16',
+            selected: false,
+          },
+          {
+            value: '17',
+            label: '17',
+            selected: false,
+          },
+          {
+            value: '18',
+            label: '18',
+            selected: false,
+          },
+          {
+            value: '19',
+            label: '19',
+            selected: false,
+          },
+          {
+            value: '20',
+            label: '20',
+            selected: false,
+          },
+          {
+            value: '21',
+            label: '21',
+            selected: false,
+          },
+          {
+            value: '22',
+            label: '22',
+            selected: false,
+          },
+          {
+            value: '23',
+            label: '23',
+            selected: false,
+          },
+          {
+            value: '24',
+            label: '24',
+            selected: false,
+          },
+          {
+            value: '25',
+            label: '25',
+            selected: false,
+          },
+          {
+            value: '26',
+            label: '26',
+            selected: false,
+          },
+          {
+            value: '27',
+            label: '27',
+            selected: false,
+          },
+          {
+            value: '28',
+            label: '28',
+            selected: false,
+          },
+          {
+            value: '29',
+            label: '29',
+            selected: false,
+          },
+          {
+            value: '>30',
+            label: '>30',
+            selected: false,
+          },
+          {
+            value: 'Unknown',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: '5 or younger',
-          label: '5 or younger',
-          selected: true,
+      {
+        label: 'Do you consider yourself to be:',
+        type: 'SelectItem',
+        attributes: {
+          name: 'gender',
+          required: true,
+          readOnly: false,
         },
-        {
-          value: '06',
-          label: '6',
-          selected: false,
-        },
-        {
-          value: '07',
-          label: '7',
-          selected: false,
-        },
-        {
-          value: '08',
-          label: '8',
-          selected: false,
-        },
-        {
-          value: '09',
-          label: '9',
-          selected: false,
-        },
-        {
-          value: '10',
-          label: '10',
-          selected: false,
-        },
-        {
-          value: '11',
-          label: '11',
-          selected: false,
-        },
-        {
-          value: '12',
-          label: '12',
-          selected: false,
-        },
-        {
-          value: '13',
-          label: '13',
-          selected: false,
-        },
-        {
-          value: '14',
-          label: '14',
-          selected: false,
-        },
-        {
-          value: '15',
-          label: '15',
-          selected: false,
-        },
-        {
-          value: '16',
-          label: '16',
-          selected: false,
-        },
-        {
-          value: '17',
-          label: '17',
-          selected: false,
-        },
-        {
-          value: '18',
-          label: '18',
-          selected: false,
-        },
-        {
-          value: '19',
-          label: '19',
-          selected: false,
-        },
-        {
-          value: '20',
-          label: '20',
-          selected: false,
-        },
-        {
-          value: '21',
-          label: '21',
-          selected: false,
-        },
-        {
-          value: '22',
-          label: '22',
-          selected: false,
-        },
-        {
-          value: '23',
-          label: '23',
-          selected: false,
-        },
-        {
-          value: '24',
-          label: '24',
-          selected: false,
-        },
-        {
-          value: '25',
-          label: '25',
-          selected: false,
-        },
-        {
-          value: '26',
-          label: '26',
-          selected: false,
-        },
-        {
-          value: '27',
-          label: '27',
-          selected: false,
-        },
-        {
-          value: '28',
-          label: '28',
-          selected: false,
-        },
-        {
-          value: '29',
-          label: '29',
-          selected: false,
-        },
-        {
-          value: '>30',
-          label: '>30',
-          selected: false,
-        },
-        {
-          value: 'Unknown',
-          label: 'Prefer not to answer',
-          selected: false,
-        },
-      ],
-    },
-    {
-      label: 'Do you consider yourself to be:',
-      type: 'SelectItem',
-      attributes: {
-        name: 'gender',
-        required: true,
-        readOnly: false,
+        options: [
+          {
+            value: 'Agender',
+            label: 'Agender',
+            selected: true,
+          },
+          {
+            value: 'Cis Male/Man',
+            label: 'Cis Male/Man',
+            selected: false,
+          },
+          {
+            value: 'Cis Female/Woman',
+            label: 'Cis Female/Woman',
+            selected: false,
+          },
+          {
+            value: 'Non-Binary/Genderqueer/Gender fluid"',
+            label: 'Non-Binary/Genderqueer/Gender fluid"',
+            selected: false,
+          },
+          {
+            value: 'Two-Spirit',
+            label: 'Two-Spirit',
+            selected: false,
+          },
+          {
+            value: 'Trans Female/Woman',
+            label: 'Trans Female/Woman',
+            selected: false,
+          },
+          {
+            value: 'Trans Male/Man',
+            label: 'Trans Male/Man',
+            selected: false,
+          },
+          {
+            value: 'Other',
+            label: 'Other',
+            selected: false,
+          },
+          {
+            value: 'Unknown',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: 'Agender',
-          label: 'Agender',
-          selected: true,
+      {
+        label: 'Do you consider yourself to be:',
+        type: 'SelectItem',
+        attributes: {
+          name: 'sexualOrientation',
+          required: true,
+          readOnly: false,
         },
-        {
-          value: 'Cis Male/Man',
-          label: 'Cis Male/Man',
-          selected: false,
-        },
-        {
-          value: 'Cis Female/Woman',
-          label: 'Cis Female/Woman',
-          selected: false,
-        },
-        {
-          value: 'Non-Binary/Genderqueer/Gender fluid"',
-          label: 'Non-Binary/Genderqueer/Gender fluid"',
-          selected: false,
-        },
-        {
-          value: 'Two-Spirit',
-          label: 'Two-Spirit',
-          selected: false,
-        },
-        {
-          value: 'Trans Female/Woman',
-          label: 'Trans Female/Woman',
-          selected: false,
-        },
-        {
-          value: 'Trans Male/Man',
-          label: 'Trans Male/Man',
-          selected: false,
-        },
-        {
-          value: 'Other',
-          label: 'Other',
-          selected: false,
-        },
-        {
-          value: 'Unknown',
-          label: 'Prefer not to answer',
-          selected: false,
-        },
-      ],
-    },
-    {
-      label: 'Do you consider yourself to be:',
-      type: 'SelectItem',
-      attributes: {
-        name: 'sexualOrientation',
-        required: true,
-        readOnly: false,
+        options: [
+          {
+            value: 'Asexual',
+            label: 'Asexual',
+            selected: true,
+          },
+          {
+            value: 'Bisexual or Pansexual',
+            label: 'Bisexual or Pansexual',
+            selected: false,
+          },
+          {
+            value: 'Gay or Lesbian',
+            label: 'Gay or Lesbian',
+            selected: false,
+          },
+          {
+            value: 'Queer',
+            label: 'Queer',
+            selected: false,
+          },
+          {
+            value: 'Heterosexual or Straight',
+            label: 'Heterosexual or Straight',
+            selected: false,
+          },
+          {
+            value: 'Questioning or Unsure',
+            label: 'Questioning or Unsure',
+            selected: false,
+          },
+          {
+            value: 'Other',
+            label: 'Other',
+            selected: false,
+          },
+          {
+            value: 'Unknown',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: 'Asexual',
-          label: 'Asexual',
-          selected: true,
+      {
+        label: 'Are you a newcomer (i.e., Arrived in Canada within 5 years or less), recent immigrant, and/or refugee?',
+        type: 'SelectItem',
+        attributes: {
+          name: 'Newcomer',
+          required: true,
         },
-        {
-          value: 'Bisexual or Pansexual',
-          label: 'Bisexual or Pansexual',
-          selected: false,
-        },
-        {
-          value: 'Gay or Lesbian',
-          label: 'Gay or Lesbian',
-          selected: false,
-        },
-        {
-          value: 'Queer',
-          label: 'Queer',
-          selected: false,
-        },
-        {
-          value: 'Heterosexual or Straight',
-          label: 'Heterosexual or Straight',
-          selected: false,
-        },
-        {
-          value: 'Questioning or Unsure',
-          label: 'Questioning or Unsure',
-          selected: false,
-        },
-        {
-          value: 'Other',
-          label: 'Other',
-          selected: false,
-        },
-        {
-          value: 'Unknown',
-          label: 'Prefer not to answer',
-          selected: false,
-        },
-      ],
-    },
-    {
-      label: 'Are you a newcomer (i.e., Arrived in Canada within 5 years or less), recent immigrant, and/or refugee?',
-      type: 'SelectItem',
-      attributes: {
-        name: 'Newcomer',
-        required: true,
+        options: [
+          {
+            value: 'yes',
+            label: 'Yes',
+            selected: true,
+          },
+          {
+            value: 'no',
+            label: 'No',
+            selected: false,
+          },
+          {
+            value: 'Unknown',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: 'yes',
-          label: 'Yes',
-          selected: true,
+      {
+        label: 'What province or territory do you live in? ',
+        type: 'SelectItem',
+        attributes: {
+          name: 'province',
+          required: true,
         },
-        {
-          value: 'no',
-          label: 'No',
-          selected: false,
-        },
-        {
-          value: 'Unknown',
-          label: 'Prefer not to answer',
-          selected: false,
-        },
-      ],
-    },
-    {
-      label: 'What province or territory do you live in? ',
-      type: 'SelectItem',
-      attributes: {
-        name: 'province',
-        required: true,
+        options: [
+          {
+            value: 'Alberta',
+            label: 'Alberta',
+            selected: true,
+          },
+          {
+            value: 'British Columbia',
+            label: 'British Columbia',
+            selected: false,
+          },
+          {
+            value: 'Inuvialuit',
+            label: 'Inuvialuit',
+            selected: false,
+          },
+          {
+            value: 'Manitoba',
+            label: 'Manitoba',
+            selected: false,
+          },
+          {
+            value: 'New Brunswick',
+            label: 'New Brunswick',
+            selected: false,
+          },
+          {
+            value: 'Newfoundland and Labrador',
+            label: 'Newfoundland and Labrador',
+            selected: false,
+          },
+          {
+            value: 'Northwest Territories',
+            label: 'Northwest Territories',
+            selected: false,
+          },
+          {
+            value: 'Nova Scotia',
+            label: 'Nova Scotia',
+            selected: false,
+          },
+          {
+            value: 'Nunavat',
+            label: 'Nunavat',
+            selected: false,
+          },
+          {
+            value: 'Nunavik',
+            label: 'Nunavik',
+            selected: false,
+          },
+          {
+            value: 'Nunatsiavut',
+            label: 'Nunatsiavut',
+            selected: false,
+          },
+          {
+            value: 'Ontario',
+            label: 'Ontario',
+            selected: false,
+          },
+          {
+            value: 'Prince Edward Island',
+            label: 'Prince Edward Island',
+            selected: false,
+          },
+          {
+            value: 'Québec',
+            label: 'Québec',
+            selected: false,
+          },
+          {
+            value: 'Saskatchewan',
+            label: 'Saskatchewan',
+            selected: false,
+          },
+          {
+            value: 'Yukon',
+            label: 'Yukon',
+            selected: false,
+          },
+          {
+            value: 'Contacting us from outside of Canada',
+            label: 'Contacting us from outside of Canada',
+            selected: false,
+          },
+          {
+            value: 'Did not disclose/Did not ask',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: 'Alberta',
-          label: 'Alberta',
-          selected: true,
+      {
+        label: 'Tell us more about where you live…',
+        type: 'SelectItem',
+        attributes: {
+          name: 'region',
+          required: true,
         },
-        {
-          value: 'British Columbia',
-          label: 'British Columbia',
-          selected: false,
-        },
-        {
-          value: 'Inuvialuit',
-          label: 'Inuvialuit',
-          selected: false,
-        },
-        {
-          value: 'Manitoba',
-          label: 'Manitoba',
-          selected: false,
-        },
-        {
-          value: 'New Brunswick',
-          label: 'New Brunswick',
-          selected: false,
-        },
-        {
-          value: 'Newfoundland and Labrador',
-          label: 'Newfoundland and Labrador',
-          selected: false,
-        },
-        {
-          value: 'Northwest Territories',
-          label: 'Northwest Territories',
-          selected: false,
-        },
-        {
-          value: 'Nova Scotia',
-          label: 'Nova Scotia',
-          selected: false,
-        },
-        {
-          value: 'Nunavat',
-          label: 'Nunavat',
-          selected: false,
-        },
-        {
-          value: 'Nunavik',
-          label: 'Nunavik',
-          selected: false,
-        },
-        {
-          value: 'Nunatsiavut',
-          label: 'Nunatsiavut',
-          selected: false,
-        },
-        {
-          value: 'Ontario',
-          label: 'Ontario',
-          selected: false,
-        },
-        {
-          value: 'Prince Edward Island',
-          label: 'Prince Edward Island',
-          selected: false,
-        },
-        {
-          value: 'Québec',
-          label: 'Québec',
-          selected: false,
-        },
-        {
-          value: 'Saskatchewan',
-          label: 'Saskatchewan',
-          selected: false,
-        },
-        {
-          value: 'Yukon',
-          label: 'Yukon',
-          selected: false,
-        },
-        {
-          value: 'Contacting us from outside of Canada',
-          label: 'Contacting us from outside of Canada',
-          selected: false,
-        },
-        {
-          value: 'Did not disclose/Did not ask',
-          label: 'Prefer not to answer',
-          selected: false,
-        },
-      ],
-    },
-    {
-      label: 'Tell us more about where you live…',
-      type: 'SelectItem',
-      attributes: {
-        name: 'region',
-        required: true,
+        options: [
+          {
+            value: 'Rural area',
+            label: 'Rural area (less than 1,000 people)',
+            selected: true,
+          },
+          {
+            value: 'Small city/town',
+            label: 'Small city/town (approximately 1,000 to 29,999 people)',
+            selected: false,
+          },
+          {
+            value: 'Medium city',
+            label: 'Medium city (approximately 30,000 to 99,999 people)',
+            selected: false,
+          },
+          {
+            value: 'Large city/urban centre',
+            label: 'Large city/urban centre (approximately 100,000 people or more)',
+            selected: false,
+          },
+          {
+            value: 'First Nations reserve',
+            label: 'First Nations reserve',
+            selected: false,
+          },
+          {
+            value: 'Other',
+            label: 'Other',
+            selected: false,
+          },
+          {
+            value: 'Unknown',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: 'Rural area',
-          label: 'Rural area (less than 1,000 people)',
-          selected: true,
+      {
+        label: 'On a scale of 1 to 7, how upset are you right now?',
+        type: 'SelectItem',
+        attributes: {
+          name: 'upset',
+          required: true,
         },
-        {
-          value: 'Small city/town',
-          label: 'Small city/town (approximately 1,000 to 29,999 people)',
-          selected: false,
-        },
-        {
-          value: 'Medium city',
-          label: 'Medium city (approximately 30,000 to 99,999 people)',
-          selected: false,
-        },
-        {
-          value: 'Large city/urban centre',
-          label: 'Large city/urban centre (approximately 100,000 people or more)',
-          selected: false,
-        },
-        {
-          value: 'First Nations reserve',
-          label: 'First Nations reserve',
-          selected: false,
-        },
-        {
-          value: 'Other',
-          label: 'Other',
-          selected: false,
-        },
-        {
-          value: 'Unknown',
-          label: 'Prefer not to answer',
-          selected: false,
-        },
-      ],
-    },
-    {
-      label: 'On a scale of 1 to 7, how upset are you right now?',
-      type: 'SelectItem',
-      attributes: {
-        name: 'upset',
-        required: true,
+        options: [
+          {
+            value: '1',
+            label: '1 - Not Very',
+            selected: true,
+          },
+          {
+            value: '2',
+            label: '2',
+            selected: false,
+          },
+          {
+            value: '3',
+            label: '3',
+            selected: false,
+          },
+          {
+            value: '4',
+            label: '4',
+            selected: false,
+          },
+          {
+            value: '5',
+            label: '5',
+            selected: false,
+          },
+          {
+            value: '6',
+            label: '6',
+            selected: false,
+          },
+          {
+            value: '7',
+            label: '7 - Very',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: '1',
-          label: '1 - Not Very',
-          selected: true,
+      {
+        label: 'Do you consider yourself to be:',
+        type: 'SelectItem',
+        attributes: {
+          name: 'ethnicity',
+          required: false,
         },
-        {
-          value: '2',
-          label: '2',
-          selected: false,
-        },
-        {
-          value: '3',
-          label: '3',
-          selected: false,
-        },
-        {
-          value: '4',
-          label: '4',
-          selected: false,
-        },
-        {
-          value: '5',
-          label: '5',
-          selected: false,
-        },
-        {
-          value: '6',
-          label: '6',
-          selected: false,
-        },
-        {
-          value: '7',
-          label: '7 - Very',
-          selected: false,
-        },
-      ],
-    },
-    {
-      label: 'Do you consider yourself to be:',
-      type: 'SelectItem',
-      attributes: {
-        name: 'ethnicity',
-        required: false,
+        options: [
+          {
+            value: '',
+            label: '',
+            selected: true,
+          },
+          {
+            value: 'Black',
+            label: 'Black (e.g., African, Afro-Caribbean, African Canadian descent)',
+            selected: false,
+          },
+          {
+            value: 'East Asian',
+            label: 'East Asian (e.g., East Asian descent; Korean, Chinese, Japanese, etc.)',
+            selected: false,
+          },
+          {
+            value: 'Indigenous',
+            label: 'Indigenous (To North America',
+            selected: false,
+          },
+          {
+            value: 'First Nations',
+            label: 'First Nations [sub-category of Indigenous (To North America)]',
+            selected: false,
+          },
+          {
+            value: 'Métis',
+            label: 'Métis [sub-category of Indigenous (To North America)]',
+            selected: false,
+          },
+          {
+            value: 'Inuit',
+            label: 'Inuit [sub-category of Indigenous (To North America)]',
+            selected: false,
+          },
+          {
+            value: 'Indigenous (non-specified)',
+            label: 'Indigenous (non-specified) [sub-category of Indigenous (To North America)]',
+            selected: false,
+          },
+          {
+            value: 'Indigenous (Not to North America)',
+            label: 'Indigenous (Not to North America)',
+            selected: false,
+          },
+          {
+            value: 'Latin American',
+            label: 'Latin American (e.g., Latin American, Hispanic descent)',
+            selected: false,
+          },
+          {
+            value: 'Middle Eastern',
+            label:
+              'Middle Eastern (e.g., Arab, Persian, West Asian descent; Egyptian, Iranian, Lebanese, Turkish, etc.)',
+            selected: false,
+          },
+          {
+            value: 'Southeast Asian',
+            label:
+              'Southeast Asian (e.g., Southeast Asian descent; Cambodian, Filipino, Indonesian, Laotian, Vietnamese, etc.)',
+            selected: false,
+          },
+          {
+            value: 'South Asian',
+            label: 'South Asian (e.g., South Asian descent; East Indian, Afghan, Pakistani, Sri Lankan, etc.)',
+            selected: false,
+          },
+          {
+            value: 'White',
+            label: 'White (e.g., European descent)',
+            selected: false,
+          },
+          {
+            value: 'Other',
+            label: 'Other',
+            selected: false,
+          },
+          {
+            value: 'Unknown',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: '',
-          label: '',
-          selected: true,
+      {
+        label: 'We would like to learn more about you and if you are currently a student. Do you attend...?',
+        type: 'SelectItem',
+        attributes: {
+          name: 'school',
+          required: false,
         },
-        {
-          value: 'Black',
-          label: 'Black (e.g., African, Afro-Caribbean, African Canadian descent)',
-          selected: false,
-        },
-        {
-          value: 'East Asian',
-          label: 'East Asian (e.g., East Asian descent; Korean, Chinese, Japanese, etc.)',
-          selected: false,
-        },
-        {
-          value: 'Indigenous',
-          label: 'Indigenous (To North America',
-          selected: false,
-        },
-        {
-          value: 'First Nations',
-          label: 'First Nations [sub-category of Indigenous (To North America)]',
-          selected: false,
-        },
-        {
-          value: 'Métis',
-          label: 'Métis [sub-category of Indigenous (To North America)]',
-          selected: false,
-        },
-        {
-          value: 'Inuit',
-          label: 'Inuit [sub-category of Indigenous (To North America)]',
-          selected: false,
-        },
-        {
-          value: 'Indigenous (non-specified)',
-          label: 'Indigenous (non-specified) [sub-category of Indigenous (To North America)]',
-          selected: false,
-        },
-        {
-          value: 'Indigenous (Not to North America)',
-          label: 'Indigenous (Not to North America)',
-          selected: false,
-        },
-        {
-          value: 'Latin American',
-          label: 'Latin American (e.g., Latin American, Hispanic descent)',
-          selected: false,
-        },
-        {
-          value: 'Middle Eastern',
-          label: 'Middle Eastern (e.g., Arab, Persian, West Asian descent; Egyptian, Iranian, Lebanese, Turkish, etc.)',
-          selected: false,
-        },
-        {
-          value: 'Southeast Asian',
-          label:
-            'Southeast Asian (e.g., Southeast Asian descent; Cambodian, Filipino, Indonesian, Laotian, Vietnamese, etc.)',
-          selected: false,
-        },
-        {
-          value: 'South Asian',
-          label: 'South Asian (e.g., South Asian descent; East Indian, Afghan, Pakistani, Sri Lankan, etc.)',
-          selected: false,
-        },
-        {
-          value: 'White',
-          label: 'White (e.g., European descent)',
-          selected: false,
-        },
-        {
-          value: 'Other',
-          label: 'Other',
-          selected: false,
-        },
-        {
-          value: 'Unknown',
-          label: 'Prefer not to answer',
-          selected: false,
-        },
-      ],
-    },
-    {
-      label: 'We would like to learn more about you and if you are currently a student. Do you attend...?',
-      type: 'SelectItem',
-      attributes: {
-        name: 'school',
-        required: false,
+        options: [
+          {
+            value: '',
+            label: '',
+            selected: true,
+          },
+          {
+            value: 'Elementary School',
+            label: 'Elementary School',
+            selected: false,
+          },
+          {
+            value: 'Middle school/Junior High',
+            label: 'Middle school/Junior High',
+            selected: false,
+          },
+          {
+            value: 'High School',
+            label: 'High School',
+            selected: false,
+          },
+          {
+            value: 'Alternative Education School/Program',
+            label: 'Alternative Education School/Program',
+            selected: false,
+          },
+          {
+            value: 'College',
+            label: 'College',
+            selected: false,
+          },
+          {
+            value: 'University',
+            label: 'University',
+            selected: false,
+          },
+          {
+            value: 'Home School',
+            label: 'Home School',
+            selected: false,
+          },
+          {
+            value: 'Other',
+            label: 'Other',
+            selected: false,
+          },
+          {
+            value: 'Not a student',
+            label: 'Not a student',
+            selected: false,
+          },
+          {
+            value: 'Unknown',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: '',
-          label: '',
-          selected: true,
+      {
+        label: 'Which of these best describes your current living situation?:',
+        type: 'SelectItem',
+        attributes: {
+          name: 'livingSituation',
+          required: false,
         },
-        {
-          value: 'Elementary School',
-          label: 'Elementary School',
-          selected: false,
-        },
-        {
-          value: 'Middle school/Junior High',
-          label: 'Middle school/Junior High',
-          selected: false,
-        },
-        {
-          value: 'High School',
-          label: 'High School',
-          selected: false,
-        },
-        {
-          value: 'Alternative Education School/Program',
-          label: 'Alternative Education School/Program',
-          selected: false,
-        },
-        {
-          value: 'College',
-          label: 'College',
-          selected: false,
-        },
-        {
-          value: 'University',
-          label: 'University',
-          selected: false,
-        },
-        {
-          value: 'Home School',
-          label: 'Home School',
-          selected: false,
-        },
-        {
-          value: 'Other',
-          label: 'Other',
-          selected: false,
-        },
-        {
-          value: 'Not a student',
-          label: 'Not a student',
-          selected: false,
-        },
-        {
-          value: 'Unknown',
-          label: 'Prefer not to answer',
-          selected: false,
-        },
-      ],
-    },
-    {
-      label: 'Which of these best describes your current living situation?:',
-      type: 'SelectItem',
-      attributes: {
-        name: 'livingSituation',
-        required: false,
+        options: [
+          {
+            value: '',
+            label: '',
+            selected: true,
+          },
+          {
+            value: 'Living with family members/guardians',
+            label: 'Living with family members/guardians',
+            selected: false,
+          },
+          {
+            value: 'Member of a military family',
+            label: 'Member of a military family',
+            selected: false,
+          },
+          {
+            value: 'Living independently/with peers',
+            label: 'Living independently/with peers',
+            selected: false,
+          },
+          {
+            value: 'Living in a School residence',
+            label: 'Living in a School residence',
+            selected: false,
+          },
+          {
+            value: 'In hospital',
+            label: 'In hospital',
+            selected: false,
+          },
+          {
+            value: 'Treatment centre',
+            label: 'Treatment centre',
+            selected: false,
+          },
+          {
+            value: 'Recovery home',
+            label: 'Recovery home',
+            selected: false,
+          },
+          {
+            value: 'Assisted living centre',
+            label: 'Assisted living centre',
+            selected: false,
+          },
+          {
+            value: 'Homeless',
+            label: 'Homeless (living in a shelter, on the streets or staying with people temporarily)',
+            selected: false,
+          },
+          {
+            value: 'In care',
+            label: 'In care',
+            selected: false,
+          },
+          {
+            value: 'Other',
+            label: 'Other',
+            selected: false,
+          },
+          {
+            value: 'Unknown',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: '',
-          label: '',
-          selected: true,
+    ],
+    submitLabel: 'Start Chat!',
+  },
+  'fr-CA': {
+    description: `Bienvenue à Jeunesse, J'écoute. Pour nous aider à mieux vous servir, veuillez répondre aux questions suivantes.`,
+    fields: [
+      {
+        type: 'InputItem',
+        label: 'Nickname (please do not share your real name)',
+        attributes: {
+          name: 'nickname',
+          type: 'text',
+          placeholder: 'Guest',
+          required: true,
         },
-        {
-          value: 'Living with family members/guardians',
-          label: 'Living with family members/guardians',
-          selected: false,
+      },
+      {
+        label: 'How old are you?',
+        type: 'SelectItem',
+        attributes: {
+          name: 'age',
+          required: true,
+          readOnly: false,
         },
-        {
-          value: 'Member of a military family',
-          label: 'Member of a military family',
-          selected: false,
+        options: [
+          {
+            value: '5 or younger',
+            label: '5 or younger',
+            selected: true,
+          },
+          {
+            value: '06',
+            label: '6',
+            selected: false,
+          },
+          {
+            value: '07',
+            label: '7',
+            selected: false,
+          },
+          {
+            value: '08',
+            label: '8',
+            selected: false,
+          },
+          {
+            value: '09',
+            label: '9',
+            selected: false,
+          },
+          {
+            value: '10',
+            label: '10',
+            selected: false,
+          },
+          {
+            value: '11',
+            label: '11',
+            selected: false,
+          },
+          {
+            value: '12',
+            label: '12',
+            selected: false,
+          },
+          {
+            value: '13',
+            label: '13',
+            selected: false,
+          },
+          {
+            value: '14',
+            label: '14',
+            selected: false,
+          },
+          {
+            value: '15',
+            label: '15',
+            selected: false,
+          },
+          {
+            value: '16',
+            label: '16',
+            selected: false,
+          },
+          {
+            value: '17',
+            label: '17',
+            selected: false,
+          },
+          {
+            value: '18',
+            label: '18',
+            selected: false,
+          },
+          {
+            value: '19',
+            label: '19',
+            selected: false,
+          },
+          {
+            value: '20',
+            label: '20',
+            selected: false,
+          },
+          {
+            value: '21',
+            label: '21',
+            selected: false,
+          },
+          {
+            value: '22',
+            label: '22',
+            selected: false,
+          },
+          {
+            value: '23',
+            label: '23',
+            selected: false,
+          },
+          {
+            value: '24',
+            label: '24',
+            selected: false,
+          },
+          {
+            value: '25',
+            label: '25',
+            selected: false,
+          },
+          {
+            value: '26',
+            label: '26',
+            selected: false,
+          },
+          {
+            value: '27',
+            label: '27',
+            selected: false,
+          },
+          {
+            value: '28',
+            label: '28',
+            selected: false,
+          },
+          {
+            value: '29',
+            label: '29',
+            selected: false,
+          },
+          {
+            value: '>30',
+            label: '>30',
+            selected: false,
+          },
+          {
+            value: 'Unknown',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
+      },
+      {
+        label: 'Do you consider yourself to be:',
+        type: 'SelectItem',
+        attributes: {
+          name: 'gender',
+          required: true,
+          readOnly: false,
         },
-        {
-          value: 'Living independently/with peers',
-          label: 'Living independently/with peers',
-          selected: false,
+        options: [
+          {
+            value: 'Agender',
+            label: 'Agender',
+            selected: true,
+          },
+          {
+            value: 'Cis Male/Man',
+            label: 'Cis Male/Man',
+            selected: false,
+          },
+          {
+            value: 'Cis Female/Woman',
+            label: 'Cis Female/Woman',
+            selected: false,
+          },
+          {
+            value: 'Non-Binary/Genderqueer/Gender fluid"',
+            label: 'Non-Binary/Genderqueer/Gender fluid"',
+            selected: false,
+          },
+          {
+            value: 'Two-Spirit',
+            label: 'Two-Spirit',
+            selected: false,
+          },
+          {
+            value: 'Trans Female/Woman',
+            label: 'Trans Female/Woman',
+            selected: false,
+          },
+          {
+            value: 'Trans Male/Man',
+            label: 'Trans Male/Man',
+            selected: false,
+          },
+          {
+            value: 'Other',
+            label: 'Other',
+            selected: false,
+          },
+          {
+            value: 'Unknown',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
+      },
+      {
+        label: 'Do you consider yourself to be:',
+        type: 'SelectItem',
+        attributes: {
+          name: 'sexualOrientation',
+          required: true,
+          readOnly: false,
         },
-        {
-          value: 'Living in a School residence',
-          label: 'Living in a School residence',
-          selected: false,
+        options: [
+          {
+            value: 'Asexual',
+            label: 'Asexual',
+            selected: true,
+          },
+          {
+            value: 'Bisexual or Pansexual',
+            label: 'Bisexual or Pansexual',
+            selected: false,
+          },
+          {
+            value: 'Gay or Lesbian',
+            label: 'Gay or Lesbian',
+            selected: false,
+          },
+          {
+            value: 'Queer',
+            label: 'Queer',
+            selected: false,
+          },
+          {
+            value: 'Heterosexual or Straight',
+            label: 'Heterosexual or Straight',
+            selected: false,
+          },
+          {
+            value: 'Questioning or Unsure',
+            label: 'Questioning or Unsure',
+            selected: false,
+          },
+          {
+            value: 'Other',
+            label: 'Other',
+            selected: false,
+          },
+          {
+            value: 'Unknown',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
+      },
+      {
+        label: 'Are you a newcomer (i.e., Arrived in Canada within 5 years or less), recent immigrant, and/or refugee?',
+        type: 'SelectItem',
+        attributes: {
+          name: 'Newcomer',
+          required: true,
         },
-        {
-          value: 'In hospital',
-          label: 'In hospital',
-          selected: false,
+        options: [
+          {
+            value: 'yes',
+            label: 'Yes',
+            selected: true,
+          },
+          {
+            value: 'no',
+            label: 'No',
+            selected: false,
+          },
+          {
+            value: 'Unknown',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
+      },
+      {
+        label: 'What province or territory do you live in? ',
+        type: 'SelectItem',
+        attributes: {
+          name: 'province',
+          required: true,
         },
-        {
-          value: 'Treatment centre',
-          label: 'Treatment centre',
-          selected: false,
+        options: [
+          {
+            value: 'Alberta',
+            label: 'Alberta',
+            selected: true,
+          },
+          {
+            value: 'British Columbia',
+            label: 'British Columbia',
+            selected: false,
+          },
+          {
+            value: 'Inuvialuit',
+            label: 'Inuvialuit',
+            selected: false,
+          },
+          {
+            value: 'Manitoba',
+            label: 'Manitoba',
+            selected: false,
+          },
+          {
+            value: 'New Brunswick',
+            label: 'New Brunswick',
+            selected: false,
+          },
+          {
+            value: 'Newfoundland and Labrador',
+            label: 'Newfoundland and Labrador',
+            selected: false,
+          },
+          {
+            value: 'Northwest Territories',
+            label: 'Northwest Territories',
+            selected: false,
+          },
+          {
+            value: 'Nova Scotia',
+            label: 'Nova Scotia',
+            selected: false,
+          },
+          {
+            value: 'Nunavat',
+            label: 'Nunavat',
+            selected: false,
+          },
+          {
+            value: 'Nunavik',
+            label: 'Nunavik',
+            selected: false,
+          },
+          {
+            value: 'Nunatsiavut',
+            label: 'Nunatsiavut',
+            selected: false,
+          },
+          {
+            value: 'Ontario',
+            label: 'Ontario',
+            selected: false,
+          },
+          {
+            value: 'Prince Edward Island',
+            label: 'Prince Edward Island',
+            selected: false,
+          },
+          {
+            value: 'Québec',
+            label: 'Québec',
+            selected: false,
+          },
+          {
+            value: 'Saskatchewan',
+            label: 'Saskatchewan',
+            selected: false,
+          },
+          {
+            value: 'Yukon',
+            label: 'Yukon',
+            selected: false,
+          },
+          {
+            value: 'Contacting us from outside of Canada',
+            label: 'Contacting us from outside of Canada',
+            selected: false,
+          },
+          {
+            value: 'Did not disclose/Did not ask',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
+      },
+      {
+        label: 'Tell us more about where you live…',
+        type: 'SelectItem',
+        attributes: {
+          name: 'region',
+          required: true,
         },
-        {
-          value: 'Recovery home',
-          label: 'Recovery home',
-          selected: false,
+        options: [
+          {
+            value: 'Rural area',
+            label: 'Rural area (less than 1,000 people)',
+            selected: true,
+          },
+          {
+            value: 'Small city/town',
+            label: 'Small city/town (approximately 1,000 to 29,999 people)',
+            selected: false,
+          },
+          {
+            value: 'Medium city',
+            label: 'Medium city (approximately 30,000 to 99,999 people)',
+            selected: false,
+          },
+          {
+            value: 'Large city/urban centre',
+            label: 'Large city/urban centre (approximately 100,000 people or more)',
+            selected: false,
+          },
+          {
+            value: 'First Nations reserve',
+            label: 'First Nations reserve',
+            selected: false,
+          },
+          {
+            value: 'Other',
+            label: 'Other',
+            selected: false,
+          },
+          {
+            value: 'Unknown',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
+      },
+      {
+        label: 'On a scale of 1 to 7, how upset are you right now?',
+        type: 'SelectItem',
+        attributes: {
+          name: 'upset',
+          required: true,
         },
-        {
-          value: 'Assisted living centre',
-          label: 'Assisted living centre',
-          selected: false,
+        options: [
+          {
+            value: '1',
+            label: '1 - Not Very',
+            selected: true,
+          },
+          {
+            value: '2',
+            label: '2',
+            selected: false,
+          },
+          {
+            value: '3',
+            label: '3',
+            selected: false,
+          },
+          {
+            value: '4',
+            label: '4',
+            selected: false,
+          },
+          {
+            value: '5',
+            label: '5',
+            selected: false,
+          },
+          {
+            value: '6',
+            label: '6',
+            selected: false,
+          },
+          {
+            value: '7',
+            label: '7 - Very',
+            selected: false,
+          },
+        ],
+      },
+      {
+        label: 'Do you consider yourself to be:',
+        type: 'SelectItem',
+        attributes: {
+          name: 'ethnicity',
+          required: false,
         },
-        {
-          value: 'Homeless',
-          label: 'Homeless (living in a shelter, on the streets or staying with people temporarily)',
-          selected: false,
+        options: [
+          {
+            value: '',
+            label: '',
+            selected: true,
+          },
+          {
+            value: 'Black',
+            label: 'Black (e.g., African, Afro-Caribbean, African Canadian descent)',
+            selected: false,
+          },
+          {
+            value: 'East Asian',
+            label: 'East Asian (e.g., East Asian descent; Korean, Chinese, Japanese, etc.)',
+            selected: false,
+          },
+          {
+            value: 'Indigenous',
+            label: 'Indigenous (To North America',
+            selected: false,
+          },
+          {
+            value: 'First Nations',
+            label: 'First Nations [sub-category of Indigenous (To North America)]',
+            selected: false,
+          },
+          {
+            value: 'Métis',
+            label: 'Métis [sub-category of Indigenous (To North America)]',
+            selected: false,
+          },
+          {
+            value: 'Inuit',
+            label: 'Inuit [sub-category of Indigenous (To North America)]',
+            selected: false,
+          },
+          {
+            value: 'Indigenous (non-specified)',
+            label: 'Indigenous (non-specified) [sub-category of Indigenous (To North America)]',
+            selected: false,
+          },
+          {
+            value: 'Indigenous (Not to North America)',
+            label: 'Indigenous (Not to North America)',
+            selected: false,
+          },
+          {
+            value: 'Latin American',
+            label: 'Latin American (e.g., Latin American, Hispanic descent)',
+            selected: false,
+          },
+          {
+            value: 'Middle Eastern',
+            label:
+              'Middle Eastern (e.g., Arab, Persian, West Asian descent; Egyptian, Iranian, Lebanese, Turkish, etc.)',
+            selected: false,
+          },
+          {
+            value: 'Southeast Asian',
+            label:
+              'Southeast Asian (e.g., Southeast Asian descent; Cambodian, Filipino, Indonesian, Laotian, Vietnamese, etc.)',
+            selected: false,
+          },
+          {
+            value: 'South Asian',
+            label: 'South Asian (e.g., South Asian descent; East Indian, Afghan, Pakistani, Sri Lankan, etc.)',
+            selected: false,
+          },
+          {
+            value: 'White',
+            label: 'White (e.g., European descent)',
+            selected: false,
+          },
+          {
+            value: 'Other',
+            label: 'Other',
+            selected: false,
+          },
+          {
+            value: 'Unknown',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
+      },
+      {
+        label: 'We would like to learn more about you and if you are currently a student. Do you attend...?',
+        type: 'SelectItem',
+        attributes: {
+          name: 'school',
+          required: false,
         },
-        {
-          value: 'In care',
-          label: 'In care',
-          selected: false,
+        options: [
+          {
+            value: '',
+            label: '',
+            selected: true,
+          },
+          {
+            value: 'Elementary School',
+            label: 'Elementary School',
+            selected: false,
+          },
+          {
+            value: 'Middle school/Junior High',
+            label: 'Middle school/Junior High',
+            selected: false,
+          },
+          {
+            value: 'High School',
+            label: 'High School',
+            selected: false,
+          },
+          {
+            value: 'Alternative Education School/Program',
+            label: 'Alternative Education School/Program',
+            selected: false,
+          },
+          {
+            value: 'College',
+            label: 'College',
+            selected: false,
+          },
+          {
+            value: 'University',
+            label: 'University',
+            selected: false,
+          },
+          {
+            value: 'Home School',
+            label: 'Home School',
+            selected: false,
+          },
+          {
+            value: 'Other',
+            label: 'Other',
+            selected: false,
+          },
+          {
+            value: 'Not a student',
+            label: 'Not a student',
+            selected: false,
+          },
+          {
+            value: 'Unknown',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
+      },
+      {
+        label: 'Which of these best describes your current living situation?:',
+        type: 'SelectItem',
+        attributes: {
+          name: 'livingSituation',
+          required: false,
         },
-        {
-          value: 'Other',
-          label: 'Other',
-          selected: false,
-        },
-        {
-          value: 'Unknown',
-          label: 'Prefer not to answer',
-          selected: false,
-        },
-      ],
-    },
-  ],
-  submitLabel: 'Start Chat!',
+        options: [
+          {
+            value: '',
+            label: '',
+            selected: true,
+          },
+          {
+            value: 'Living with family members/guardians',
+            label: 'Living with family members/guardians',
+            selected: false,
+          },
+          {
+            value: 'Member of a military family',
+            label: 'Member of a military family',
+            selected: false,
+          },
+          {
+            value: 'Living independently/with peers',
+            label: 'Living independently/with peers',
+            selected: false,
+          },
+          {
+            value: 'Living in a School residence',
+            label: 'Living in a School residence',
+            selected: false,
+          },
+          {
+            value: 'In hospital',
+            label: 'In hospital',
+            selected: false,
+          },
+          {
+            value: 'Treatment centre',
+            label: 'Treatment centre',
+            selected: false,
+          },
+          {
+            value: 'Recovery home',
+            label: 'Recovery home',
+            selected: false,
+          },
+          {
+            value: 'Assisted living centre',
+            label: 'Assisted living centre',
+            selected: false,
+          },
+          {
+            value: 'Homeless',
+            label: 'Homeless (living in a shelter, on the streets or staying with people temporarily)',
+            selected: false,
+          },
+          {
+            value: 'In care',
+            label: 'In care',
+            selected: false,
+          },
+          {
+            value: 'Other',
+            label: 'Other',
+            selected: false,
+          },
+          {
+            value: 'Unknown',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
+      },
+    ],
+    submitLabel: 'Start Chat!',
+  },
 };
 
 const closedHours: PreEngagementConfig = {

--- a/configurations/ca-staging.ts
+++ b/configurations/ca-staging.ts
@@ -14,7 +14,14 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
+import {
+  PreEngagementConfig,
+  Translations,
+  Configuration,
+  MapHelplineLanguage,
+  ContactType,
+  LocalizedFormAttributes,
+} from '../types';
 
 const accountSid = 'ACeb335f4685aa874fddf00cdd7c2946bd';
 const flexFlowSid = 'FO45c6ac308207b8b17bd990eadf5246fe';
@@ -35,7 +42,6 @@ const translations: Translations = {
     MessageCanvasTrayButton: 'Start New Chat',
     MessageCanvasTrayContent: '',
     AutoFirstMessage: 'Incoming webchat contact from',
-    StartChat: 'Start Chat!',
   },
   'fr-CA': {
     WelcomeMessage: "Bienvenue à Jeunesse, J'écoute",
@@ -64,723 +70,727 @@ const translations: Translations = {
     FieldValidationRequiredField: 'Champs requis',
     PreEngagementDescription: 'Commençons',
     BotGreeting: 'Comment je peux aider?',
+    PreEngagementFormDescription: `Bienvenue à Jeunesse, J'écoute. Pour nous aider à mieux vous servir, veuillez répondre aux questions suivantes.`,
   },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: 'Welcome to Kids Help Phone. To help us serve you better, please answer the following questions.',
-  fields: [
-    {
-      type: 'InputItem',
-      label: 'Nickname (please do not share your real name)',
-      attributes: {
-        name: 'nickname',
-        type: 'text',
-        placeholder: 'Guest',
-        required: true,
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-CA': {
+    description: 'Welcome to Kids Help Phone. To help us serve you better, please answer the following questions.',
+    fields: [
+      {
+        type: 'InputItem',
+        label: 'Nickname (please do not share your real name)',
+        attributes: {
+          name: 'nickname',
+          type: 'text',
+          placeholder: 'Guest',
+          required: true,
+        },
       },
-    },
-    {
-      label: 'How old are you?',
-      type: 'SelectItem',
-      attributes: {
-        name: 'age',
-        required: true,
-        readOnly: false,
+      {
+        label: 'How old are you?',
+        type: 'SelectItem',
+        attributes: {
+          name: 'age',
+          required: true,
+          readOnly: false,
+        },
+        options: [
+          {
+            value: '5 or younger',
+            label: '5 or younger',
+            selected: true,
+          },
+          {
+            value: '06',
+            label: '6',
+            selected: false,
+          },
+          {
+            value: '07',
+            label: '7',
+            selected: false,
+          },
+          {
+            value: '08',
+            label: '8',
+            selected: false,
+          },
+          {
+            value: '09',
+            label: '9',
+            selected: false,
+          },
+          {
+            value: '10',
+            label: '10',
+            selected: false,
+          },
+          {
+            value: '11',
+            label: '11',
+            selected: false,
+          },
+          {
+            value: '12',
+            label: '12',
+            selected: false,
+          },
+          {
+            value: '13',
+            label: '13',
+            selected: false,
+          },
+          {
+            value: '14',
+            label: '14',
+            selected: false,
+          },
+          {
+            value: '15',
+            label: '15',
+            selected: false,
+          },
+          {
+            value: '16',
+            label: '16',
+            selected: false,
+          },
+          {
+            value: '17',
+            label: '17',
+            selected: false,
+          },
+          {
+            value: '18',
+            label: '18',
+            selected: false,
+          },
+          {
+            value: '19',
+            label: '19',
+            selected: false,
+          },
+          {
+            value: '20',
+            label: '20',
+            selected: false,
+          },
+          {
+            value: '21',
+            label: '21',
+            selected: false,
+          },
+          {
+            value: '22',
+            label: '22',
+            selected: false,
+          },
+          {
+            value: '23',
+            label: '23',
+            selected: false,
+          },
+          {
+            value: '24',
+            label: '24',
+            selected: false,
+          },
+          {
+            value: '25',
+            label: '25',
+            selected: false,
+          },
+          {
+            value: '26',
+            label: '26',
+            selected: false,
+          },
+          {
+            value: '27',
+            label: '27',
+            selected: false,
+          },
+          {
+            value: '28',
+            label: '28',
+            selected: false,
+          },
+          {
+            value: '29',
+            label: '29',
+            selected: false,
+          },
+          {
+            value: '>30',
+            label: '>30',
+            selected: false,
+          },
+          {
+            value: 'Unknown',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: '5 or younger',
-          label: '5 or younger',
-          selected: true,
+      {
+        label: 'Do you consider yourself to be:',
+        type: 'SelectItem',
+        attributes: {
+          name: 'gender',
+          required: true,
+          readOnly: false,
         },
-        {
-          value: '06',
-          label: '6',
-          selected: false,
-        },
-        {
-          value: '07',
-          label: '7',
-          selected: false,
-        },
-        {
-          value: '08',
-          label: '8',
-          selected: false,
-        },
-        {
-          value: '09',
-          label: '9',
-          selected: false,
-        },
-        {
-          value: '10',
-          label: '10',
-          selected: false,
-        },
-        {
-          value: '11',
-          label: '11',
-          selected: false,
-        },
-        {
-          value: '12',
-          label: '12',
-          selected: false,
-        },
-        {
-          value: '13',
-          label: '13',
-          selected: false,
-        },
-        {
-          value: '14',
-          label: '14',
-          selected: false,
-        },
-        {
-          value: '15',
-          label: '15',
-          selected: false,
-        },
-        {
-          value: '16',
-          label: '16',
-          selected: false,
-        },
-        {
-          value: '17',
-          label: '17',
-          selected: false,
-        },
-        {
-          value: '18',
-          label: '18',
-          selected: false,
-        },
-        {
-          value: '19',
-          label: '19',
-          selected: false,
-        },
-        {
-          value: '20',
-          label: '20',
-          selected: false,
-        },
-        {
-          value: '21',
-          label: '21',
-          selected: false,
-        },
-        {
-          value: '22',
-          label: '22',
-          selected: false,
-        },
-        {
-          value: '23',
-          label: '23',
-          selected: false,
-        },
-        {
-          value: '24',
-          label: '24',
-          selected: false,
-        },
-        {
-          value: '25',
-          label: '25',
-          selected: false,
-        },
-        {
-          value: '26',
-          label: '26',
-          selected: false,
-        },
-        {
-          value: '27',
-          label: '27',
-          selected: false,
-        },
-        {
-          value: '28',
-          label: '28',
-          selected: false,
-        },
-        {
-          value: '29',
-          label: '29',
-          selected: false,
-        },
-        {
-          value: '>30',
-          label: '>30',
-          selected: false,
-        },
-        {
-          value: 'Unknown',
-          label: 'Prefer not to answer',
-          selected: false,
-        },
-      ],
-    },
-    {
-      label: 'Do you consider yourself to be:',
-      type: 'SelectItem',
-      attributes: {
-        name: 'gender',
-        required: true,
-        readOnly: false,
+        options: [
+          {
+            value: 'Agender',
+            label: 'Agender',
+            selected: true,
+          },
+          {
+            value: 'Cis Male/Man',
+            label: 'Cis Male/Man',
+            selected: false,
+          },
+          {
+            value: 'Cis Female/Woman',
+            label: 'Cis Female/Woman',
+            selected: false,
+          },
+          {
+            value: 'Non-Binary/Genderqueer/Gender fluid',
+            label: 'Non-Binary/Genderqueer/Gender fluid',
+            selected: false,
+          },
+          {
+            value: 'Two-Spirit',
+            label: 'Two-Spirit',
+            selected: false,
+          },
+          {
+            value: 'Trans Female/Woman',
+            label: 'Trans Female/Woman',
+            selected: false,
+          },
+          {
+            value: 'Trans Male/Man',
+            label: 'Trans Male/Man',
+            selected: false,
+          },
+          {
+            value: 'Other',
+            label: 'Other',
+            selected: false,
+          },
+          {
+            value: 'Unknown',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: 'Agender',
-          label: 'Agender',
-          selected: true,
+      {
+        label: 'Do you consider yourself to be:',
+        type: 'SelectItem',
+        attributes: {
+          name: 'sexualOrientation',
+          required: true,
+          readOnly: false,
         },
-        {
-          value: 'Cis Male/Man',
-          label: 'Cis Male/Man',
-          selected: false,
-        },
-        {
-          value: 'Cis Female/Woman',
-          label: 'Cis Female/Woman',
-          selected: false,
-        },
-        {
-          value: 'Non-Binary/Genderqueer/Gender fluid"',
-          label: 'Non-Binary/Genderqueer/Gender fluid"',
-          selected: false,
-        },
-        {
-          value: 'Two-Spirit',
-          label: 'Two-Spirit',
-          selected: false,
-        },
-        {
-          value: 'Trans Female/Woman',
-          label: 'Trans Female/Woman',
-          selected: false,
-        },
-        {
-          value: 'Trans Male/Man',
-          label: 'Trans Male/Man',
-          selected: false,
-        },
-        {
-          value: 'Other',
-          label: 'Other',
-          selected: false,
-        },
-        {
-          value: 'Unknown',
-          label: 'Prefer not to answer',
-          selected: false,
-        },
-      ],
-    },
-    {
-      label: 'Do you consider yourself to be:',
-      type: 'SelectItem',
-      attributes: {
-        name: 'sexualOrientation',
-        required: true,
-        readOnly: false,
+        options: [
+          {
+            value: 'Asexual',
+            label: 'Asexual',
+            selected: true,
+          },
+          {
+            value: 'Bisexual or Pansexual',
+            label: 'Bisexual or Pansexual',
+            selected: false,
+          },
+          {
+            value: 'Gay or Lesbian',
+            label: 'Gay or Lesbian',
+            selected: false,
+          },
+          {
+            value: 'Queer',
+            label: 'Queer',
+            selected: false,
+          },
+          {
+            value: 'Heterosexual or Straight',
+            label: 'Heterosexual or Straight',
+            selected: false,
+          },
+          {
+            value: 'Questioning or Unsure',
+            label: 'Questioning or Unsure',
+            selected: false,
+          },
+          {
+            value: 'Other',
+            label: 'Other',
+            selected: false,
+          },
+          {
+            value: 'Unknown',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: 'Asexual',
-          label: 'Asexual',
-          selected: true,
+      {
+        label: 'Are you a newcomer (i.e., Arrived in Canada within 5 years or less), recent immigrant, and/or refugee?',
+        type: 'SelectItem',
+        attributes: {
+          name: 'Newcomer',
+          required: true,
         },
-        {
-          value: 'Bisexual or Pansexual',
-          label: 'Bisexual or Pansexual',
-          selected: false,
-        },
-        {
-          value: 'Gay or Lesbian',
-          label: 'Gay or Lesbian',
-          selected: false,
-        },
-        {
-          value: 'Queer',
-          label: 'Queer',
-          selected: false,
-        },
-        {
-          value: 'Heterosexual or Straight',
-          label: 'Heterosexual or Straight',
-          selected: false,
-        },
-        {
-          value: 'Questioning or Unsure',
-          label: 'Questioning or Unsure',
-          selected: false,
-        },
-        {
-          value: 'Other',
-          label: 'Other',
-          selected: false,
-        },
-        {
-          value: 'Unknown',
-          label: 'Prefer not to answer',
-          selected: false,
-        },
-      ],
-    },
-    {
-      label: 'Are you a newcomer (i.e., Arrived in Canada within 5 years or less), recent immigrant, and/or refugee?',
-      type: 'SelectItem',
-      attributes: {
-        name: 'Newcomer',
-        required: true,
+        options: [
+          {
+            value: 'yes',
+            label: 'Yes',
+            selected: true,
+          },
+          {
+            value: 'no',
+            label: 'No',
+            selected: false,
+          },
+          {
+            value: 'Unknown',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: 'yes',
-          label: 'Yes',
-          selected: true,
+      {
+        label: 'What province or territory do you live in? ',
+        type: 'SelectItem',
+        attributes: {
+          name: 'province',
+          required: true,
         },
-        {
-          value: 'no',
-          label: 'No',
-          selected: false,
-        },
-        {
-          value: 'Unknown',
-          label: 'Prefer not to answer',
-          selected: false,
-        },
-      ],
-    },
-    {
-      label: 'What province or territory do you live in? ',
-      type: 'SelectItem',
-      attributes: {
-        name: 'province',
-        required: true,
+        options: [
+          {
+            value: 'Alberta',
+            label: 'Alberta',
+            selected: true,
+          },
+          {
+            value: 'British Columbia',
+            label: 'British Columbia',
+            selected: false,
+          },
+          {
+            value: 'Inuvialuit',
+            label: 'Inuvialuit',
+            selected: false,
+          },
+          {
+            value: 'Manitoba',
+            label: 'Manitoba',
+            selected: false,
+          },
+          {
+            value: 'New Brunswick',
+            label: 'New Brunswick',
+            selected: false,
+          },
+          {
+            value: 'Newfoundland and Labrador',
+            label: 'Newfoundland and Labrador',
+            selected: false,
+          },
+          {
+            value: 'Northwest Territories',
+            label: 'Northwest Territories',
+            selected: false,
+          },
+          {
+            value: 'Nova Scotia',
+            label: 'Nova Scotia',
+            selected: false,
+          },
+          {
+            value: 'Nunavat',
+            label: 'Nunavat',
+            selected: false,
+          },
+          {
+            value: 'Nunavik',
+            label: 'Nunavik',
+            selected: false,
+          },
+          {
+            value: 'Nunatsiavut',
+            label: 'Nunatsiavut',
+            selected: false,
+          },
+          {
+            value: 'Ontario',
+            label: 'Ontario',
+            selected: false,
+          },
+          {
+            value: 'Prince Edward Island',
+            label: 'Prince Edward Island',
+            selected: false,
+          },
+          {
+            value: 'Québec',
+            label: 'Québec',
+            selected: false,
+          },
+          {
+            value: 'Saskatchewan',
+            label: 'Saskatchewan',
+            selected: false,
+          },
+          {
+            value: 'Yukon',
+            label: 'Yukon',
+            selected: false,
+          },
+          {
+            value: 'Contacting us from outside of Canada',
+            label: 'Contacting us from outside of Canada',
+            selected: false,
+          },
+          {
+            value: 'Did not disclose/Did not ask',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: 'Alberta',
-          label: 'Alberta',
-          selected: true,
+      {
+        label: 'Tell us more about where you live…',
+        type: 'SelectItem',
+        attributes: {
+          name: 'region',
+          required: true,
         },
-        {
-          value: 'British Columbia',
-          label: 'British Columbia',
-          selected: false,
-        },
-        {
-          value: 'Inuvialuit',
-          label: 'Inuvialuit',
-          selected: false,
-        },
-        {
-          value: 'Manitoba',
-          label: 'Manitoba',
-          selected: false,
-        },
-        {
-          value: 'New Brunswick',
-          label: 'New Brunswick',
-          selected: false,
-        },
-        {
-          value: 'Newfoundland and Labrador',
-          label: 'Newfoundland and Labrador',
-          selected: false,
-        },
-        {
-          value: 'Northwest Territories',
-          label: 'Northwest Territories',
-          selected: false,
-        },
-        {
-          value: 'Nova Scotia',
-          label: 'Nova Scotia',
-          selected: false,
-        },
-        {
-          value: 'Nunavat',
-          label: 'Nunavat',
-          selected: false,
-        },
-        {
-          value: 'Nunavik',
-          label: 'Nunavik',
-          selected: false,
-        },
-        {
-          value: 'Nunatsiavut',
-          label: 'Nunatsiavut',
-          selected: false,
-        },
-        {
-          value: 'Ontario',
-          label: 'Ontario',
-          selected: false,
-        },
-        {
-          value: 'Prince Edward Island',
-          label: 'Prince Edward Island',
-          selected: false,
-        },
-        {
-          value: 'Québec',
-          label: 'Québec',
-          selected: false,
-        },
-        {
-          value: 'Saskatchewan',
-          label: 'Saskatchewan',
-          selected: false,
-        },
-        {
-          value: 'Yukon',
-          label: 'Yukon',
-          selected: false,
-        },
-        {
-          value: 'Contacting us from outside of Canada',
-          label: 'Contacting us from outside of Canada',
-          selected: false,
-        },
-        {
-          value: 'Did not disclose/Did not ask',
-          label: 'Prefer not to answer',
-          selected: false,
-        },
-      ],
-    },
-    {
-      label: 'Tell us more about where you live…',
-      type: 'SelectItem',
-      attributes: {
-        name: 'region',
-        required: true,
+        options: [
+          {
+            value: 'Rural area',
+            label: 'Rural area (less than 1,000 people)',
+            selected: true,
+          },
+          {
+            value: 'Small city/town',
+            label: 'Small city/town (approximately 1,000 to 29,999 people)',
+            selected: false,
+          },
+          {
+            value: 'Medium city',
+            label: 'Medium city (approximately 30,000 to 99,999 people)',
+            selected: false,
+          },
+          {
+            value: 'Large city/urban centre',
+            label: 'Large city/urban centre (approximately 100,000 people or more)',
+            selected: false,
+          },
+          {
+            value: 'First Nations reserve',
+            label: 'First Nations reserve',
+            selected: false,
+          },
+          {
+            value: 'Other',
+            label: 'Other',
+            selected: false,
+          },
+          {
+            value: 'Unknown',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: 'Rural area',
-          label: 'Rural area (less than 1,000 people)',
-          selected: true,
+      {
+        label: 'On a scale of 1 to 7, how upset are you right now?',
+        type: 'SelectItem',
+        attributes: {
+          name: 'upset',
+          required: true,
         },
-        {
-          value: 'Small city/town',
-          label: 'Small city/town (approximately 1,000 to 29,999 people)',
-          selected: false,
-        },
-        {
-          value: 'Medium city',
-          label: 'Medium city (approximately 30,000 to 99,999 people)',
-          selected: false,
-        },
-        {
-          value: 'Large city/urban centre',
-          label: 'Large city/urban centre (approximately 100,000 people or more)',
-          selected: false,
-        },
-        {
-          value: 'First Nations reserve',
-          label: 'First Nations reserve',
-          selected: false,
-        },
-        {
-          value: 'Other',
-          label: 'Other',
-          selected: false,
-        },
-        {
-          value: 'Unknown',
-          label: 'Prefer not to answer',
-          selected: false,
-        },
-      ],
-    },
-    {
-      label: 'On a scale of 1 to 7, how upset are you right now?',
-      type: 'SelectItem',
-      attributes: {
-        name: 'upset',
-        required: true,
+        options: [
+          {
+            value: '1',
+            label: '1 - Not Very',
+            selected: true,
+          },
+          {
+            value: '2',
+            label: '2',
+            selected: false,
+          },
+          {
+            value: '3',
+            label: '3',
+            selected: false,
+          },
+          {
+            value: '4',
+            label: '4',
+            selected: false,
+          },
+          {
+            value: '5',
+            label: '5',
+            selected: false,
+          },
+          {
+            value: '6',
+            label: '6',
+            selected: false,
+          },
+          {
+            value: '7',
+            label: '7 - Very',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: '1',
-          label: '1 - Not Very',
-          selected: true,
+      {
+        label: 'Do you consider yourself to be:',
+        type: 'SelectItem',
+        attributes: {
+          name: 'ethnicity',
+          required: false,
         },
-        {
-          value: '2',
-          label: '2',
-          selected: false,
-        },
-        {
-          value: '3',
-          label: '3',
-          selected: false,
-        },
-        {
-          value: '4',
-          label: '4',
-          selected: false,
-        },
-        {
-          value: '5',
-          label: '5',
-          selected: false,
-        },
-        {
-          value: '6',
-          label: '6',
-          selected: false,
-        },
-        {
-          value: '7',
-          label: '7 - Very',
-          selected: false,
-        },
-      ],
-    },
-    {
-      label: 'Do you consider yourself to be:',
-      type: 'SelectItem',
-      attributes: {
-        name: 'ethnicity',
-        required: false,
+        options: [
+          {
+            value: '',
+            label: '',
+            selected: true,
+          },
+          {
+            value: 'Black',
+            label: 'Black (e.g., African, Afro-Caribbean, African Canadian descent)',
+            selected: false,
+          },
+          {
+            value: 'East Asian',
+            label: 'East Asian (e.g., East Asian descent; Korean, Chinese, Japanese, etc.)',
+            selected: false,
+          },
+          {
+            value: 'Indigenous',
+            label: 'Indigenous (To North America',
+            selected: false,
+          },
+          {
+            value: 'First Nations',
+            label: 'First Nations [sub-category of Indigenous (To North America)]',
+            selected: false,
+          },
+          {
+            value: 'Métis',
+            label: 'Métis [sub-category of Indigenous (To North America)]',
+            selected: false,
+          },
+          {
+            value: 'Inuit',
+            label: 'Inuit [sub-category of Indigenous (To North America)]',
+            selected: false,
+          },
+          {
+            value: 'Indigenous (non-specified)',
+            label: 'Indigenous (non-specified) [sub-category of Indigenous (To North America)]',
+            selected: false,
+          },
+          {
+            value: 'Indigenous (Not to North America)',
+            label: 'Indigenous (Not to North America)',
+            selected: false,
+          },
+          {
+            value: 'Latin American',
+            label: 'Latin American (e.g., Latin American, Hispanic descent)',
+            selected: false,
+          },
+          {
+            value: 'Middle Eastern',
+            label:
+              'Middle Eastern (e.g., Arab, Persian, West Asian descent; Egyptian, Iranian, Lebanese, Turkish, etc.)',
+            selected: false,
+          },
+          {
+            value: 'Southeast Asian',
+            label:
+              'Southeast Asian (e.g., Southeast Asian descent; Cambodian, Filipino, Indonesian, Laotian, Vietnamese, etc.)',
+            selected: false,
+          },
+          {
+            value: 'South Asian',
+            label: 'South Asian (e.g., South Asian descent; East Indian, Afghan, Pakistani, Sri Lankan, etc.)',
+            selected: false,
+          },
+          {
+            value: 'White',
+            label: 'White (e.g., European descent)',
+            selected: false,
+          },
+          {
+            value: 'Other',
+            label: 'Other',
+            selected: false,
+          },
+          {
+            value: 'Unknown',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: '',
-          label: '',
-          selected: true,
+      {
+        label: 'We would like to learn more about you and if you are currently a student. Do you attend...?',
+        type: 'SelectItem',
+        attributes: {
+          name: 'school',
+          required: false,
         },
-        {
-          value: 'Black',
-          label: 'Black (e.g., African, Afro-Caribbean, African Canadian descent)',
-          selected: false,
-        },
-        {
-          value: 'East Asian',
-          label: 'East Asian (e.g., East Asian descent; Korean, Chinese, Japanese, etc.)',
-          selected: false,
-        },
-        {
-          value: 'Indigenous',
-          label: 'Indigenous (To North America',
-          selected: false,
-        },
-        {
-          value: 'First Nations',
-          label: 'First Nations [sub-category of Indigenous (To North America)]',
-          selected: false,
-        },
-        {
-          value: 'Métis',
-          label: 'Métis [sub-category of Indigenous (To North America)]',
-          selected: false,
-        },
-        {
-          value: 'Inuit',
-          label: 'Inuit [sub-category of Indigenous (To North America)]',
-          selected: false,
-        },
-        {
-          value: 'Indigenous (non-specified)',
-          label: 'Indigenous (non-specified) [sub-category of Indigenous (To North America)]',
-          selected: false,
-        },
-        {
-          value: 'Indigenous (Not to North America)',
-          label: 'Indigenous (Not to North America)',
-          selected: false,
-        },
-        {
-          value: 'Latin American',
-          label: 'Latin American (e.g., Latin American, Hispanic descent)',
-          selected: false,
-        },
-        {
-          value: 'Middle Eastern',
-          label: 'Middle Eastern (e.g., Arab, Persian, West Asian descent; Egyptian, Iranian, Lebanese, Turkish, etc.)',
-          selected: false,
-        },
-        {
-          value: 'Southeast Asian',
-          label:
-            'Southeast Asian (e.g., Southeast Asian descent; Cambodian, Filipino, Indonesian, Laotian, Vietnamese, etc.)',
-          selected: false,
-        },
-        {
-          value: 'South Asian',
-          label: 'South Asian (e.g., South Asian descent; East Indian, Afghan, Pakistani, Sri Lankan, etc.)',
-          selected: false,
-        },
-        {
-          value: 'White',
-          label: 'White (e.g., European descent)',
-          selected: false,
-        },
-        {
-          value: 'Other',
-          label: 'Other',
-          selected: false,
-        },
-        {
-          value: 'Unknown',
-          label: 'Prefer not to answer',
-          selected: false,
-        },
-      ],
-    },
-    {
-      label: 'We would like to learn more about you and if you are currently a student. Do you attend...?',
-      type: 'SelectItem',
-      attributes: {
-        name: 'school',
-        required: false,
+        options: [
+          {
+            value: '',
+            label: '',
+            selected: true,
+          },
+          {
+            value: 'Elementary School',
+            label: 'Elementary School',
+            selected: false,
+          },
+          {
+            value: 'Middle school/Junior High',
+            label: 'Middle school/Junior High',
+            selected: false,
+          },
+          {
+            value: 'High School',
+            label: 'High School',
+            selected: false,
+          },
+          {
+            value: 'Alternative Education School/Program',
+            label: 'Alternative Education School/Program',
+            selected: false,
+          },
+          {
+            value: 'College',
+            label: 'College',
+            selected: false,
+          },
+          {
+            value: 'University',
+            label: 'University',
+            selected: false,
+          },
+          {
+            value: 'Home School',
+            label: 'Home School',
+            selected: false,
+          },
+          {
+            value: 'Other',
+            label: 'Other',
+            selected: false,
+          },
+          {
+            value: 'Not a student',
+            label: 'Not a student',
+            selected: false,
+          },
+          {
+            value: 'Unknown',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: '',
-          label: '',
-          selected: true,
+      {
+        label: 'Which of these best describes your current living situation?:',
+        type: 'SelectItem',
+        attributes: {
+          name: 'livingSituation',
+          required: false,
         },
-        {
-          value: 'Elementary School',
-          label: 'Elementary School',
-          selected: false,
-        },
-        {
-          value: 'Middle school/Junior High',
-          label: 'Middle school/Junior High',
-          selected: false,
-        },
-        {
-          value: 'High School',
-          label: 'High School',
-          selected: false,
-        },
-        {
-          value: 'Alternative Education School/Program',
-          label: 'Alternative Education School/Program',
-          selected: false,
-        },
-        {
-          value: 'College',
-          label: 'College',
-          selected: false,
-        },
-        {
-          value: 'University',
-          label: 'University',
-          selected: false,
-        },
-        {
-          value: 'Home School',
-          label: 'Home School',
-          selected: false,
-        },
-        {
-          value: 'Other',
-          label: 'Other',
-          selected: false,
-        },
-        {
-          value: 'Not a student',
-          label: 'Not a student',
-          selected: false,
-        },
-        {
-          value: 'Unknown',
-          label: 'Prefer not to answer',
-          selected: false,
-        },
-      ],
-    },
-    {
-      label: 'Which of these best describes your current living situation?:',
-      type: 'SelectItem',
-      attributes: {
-        name: 'livingSituation',
-        required: false,
+        options: [
+          {
+            value: '',
+            label: '',
+            selected: true,
+          },
+          {
+            value: 'Living with family members/guardians',
+            label: 'Living with family members/guardians',
+            selected: false,
+          },
+          {
+            value: 'Member of a military family',
+            label: 'Member of a military family',
+            selected: false,
+          },
+          {
+            value: 'Living independently/with peers',
+            label: 'Living independently/with peers',
+            selected: false,
+          },
+          {
+            value: 'Living in a School residence',
+            label: 'Living in a School residence',
+            selected: false,
+          },
+          {
+            value: 'In hospital',
+            label: 'In hospital',
+            selected: false,
+          },
+          {
+            value: 'Treatment centre',
+            label: 'Treatment centre',
+            selected: false,
+          },
+          {
+            value: 'Recovery home',
+            label: 'Recovery home',
+            selected: false,
+          },
+          {
+            value: 'Assisted living centre',
+            label: 'Assisted living centre',
+            selected: false,
+          },
+          {
+            value: 'Homeless',
+            label: 'Homeless (living in a shelter, on the streets or staying with people temporarily)',
+            selected: false,
+          },
+          {
+            value: 'In care',
+            label: 'In care',
+            selected: false,
+          },
+          {
+            value: 'Other',
+            label: 'Other',
+            selected: false,
+          },
+          {
+            value: 'Unknown',
+            label: 'Prefer not to answer',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: '',
-          label: '',
-          selected: true,
-        },
-        {
-          value: 'Living with family members/guardians',
-          label: 'Living with family members/guardians',
-          selected: false,
-        },
-        {
-          value: 'Member of a military family',
-          label: 'Member of a military family',
-          selected: false,
-        },
-        {
-          value: 'Living independently/with peers',
-          label: 'Living independently/with peers',
-          selected: false,
-        },
-        {
-          value: 'Living in a School residence',
-          label: 'Living in a School residence',
-          selected: false,
-        },
-        {
-          value: 'In hospital',
-          label: 'In hospital',
-          selected: false,
-        },
-        {
-          value: 'Treatment centre',
-          label: 'Treatment centre',
-          selected: false,
-        },
-        {
-          value: 'Recovery home',
-          label: 'Recovery home',
-          selected: false,
-        },
-        {
-          value: 'Assisted living centre',
-          label: 'Assisted living centre',
-          selected: false,
-        },
-        {
-          value: 'Homeless',
-          label: 'Homeless (living in a shelter, on the streets or staying with people temporarily)',
-          selected: false,
-        },
-        {
-          value: 'In care',
-          label: 'In care',
-          selected: false,
-        },
-        {
-          value: 'Other',
-          label: 'Other',
-          selected: false,
-        },
-        {
-          value: 'Unknown',
-          label: 'Prefer not to answer',
-          selected: false,
-        },
-      ],
-    },
-  ],
-  submitLabel: 'Start Chat!',
+    ],
+    submitLabel: 'Start Chat!',
+  },
 };
 
 const closedHours: PreEngagementConfig = {

--- a/configurations/cl-staging.ts
+++ b/configurations/cl-staging.ts
@@ -14,7 +14,14 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import {PreEngagementConfig,Translations,Configuration,MapHelplineLanguage,ContactType} from '../types'
+import {
+  PreEngagementConfig,
+  Translations,
+  Configuration,
+  MapHelplineLanguage,
+  ContactType,
+  LocalizedFormAttributes,
+} from '../types';
 
 const accountSid = 'AC6ca34b61e7bf2d7cf8b8ca24e7efe65f';
 const flexFlowSid = 'FO005120845e65f5d54a17b8ab6d0bf3f3';
@@ -22,31 +29,29 @@ const defaultLanguage = 'es-CL';
 const captureIp = true;
 const contactType: ContactType = 'email';
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: "Bievenido a Línea Libre",
-  fields:
-    [
+const preEngagementConfig: LocalizedFormAttributes = {
+  'es-CL': {
+    description: 'Bievenido a Línea Libre',
+    fields: [
       {
-        type: "InputItem",
-        label: "Email",
+        type: 'InputItem',
+        label: 'Email',
         attributes: {
-          name: "contactIdentifier",
-          type: "email",
-          placeholder: "Email",
+          name: 'contactIdentifier',
+          type: 'email',
+          placeholder: 'Email',
           required: true,
         },
-
       },
       {
-        type: "InputItem",
-        label: "Edad",
+        type: 'InputItem',
+        label: 'Edad',
         attributes: {
-          name: "age",
-          type: "text",
-          placeholder: "Edad",
+          name: 'age',
+          type: 'text',
+          placeholder: 'Edad',
           required: true,
         },
-
       },
       {
         label: '¿Cuál es tu género?',
@@ -79,8 +84,9 @@ const preEngagementConfig: PreEngagementConfig = {
           },
         ],
       },
-  ],
-  submitLabel: 'Comenzar Nuevo Chat!',
+    ],
+    submitLabel: 'Comenzar Nuevo Chat!',
+  },
 };
 
 const translations: Translations = {
@@ -95,35 +101,34 @@ const translations: Translations = {
     MessageCanvasTrayButton: 'Start New Chat',
   },
   'es-CL': {
-    WelcomeMessage: "¡Bienvenido a Línea Libre!",
+    WelcomeMessage: '¡Bienvenido a Línea Libre!',
     MessageCanvasTrayContent: '',
     MessageInputDisabledReasonHold:
-      "Muchas gracias por la información. Lo transferiremos ahora. Por favor espere for un agente.",
+      'Muchas gracias por la información. Lo transferiremos ahora. Por favor espere for un agente.',
     AutoFirstMessage: 'Nuevo contacto del webchat de',
-    TypingIndicator: "{0} está escribiendo ... ",
+    TypingIndicator: '{0} está escribiendo ... ',
     StartChat: 'Comienza a Chatear!',
-    MessageCanvasTrayButton: "Comenzar Nuevo Chat",
-    EntryPointTagline: "Chatea con nosotros",
-    InvalidPreEngagementMessage: "Los formularios previos al compromiso no se han establecido y son necesarios para iniciar el chat web. Por favor configúrelos ahora en la configuración.",
-    InvalidPreEngagementButton: "Aprende más",
-    PredefinedChatMessageAuthorName: "Bot",
-    PredefinedChatMessageBody: "¡Hola! ¿Cómo podemos ayudarte hoy?",
-    InputPlaceHolder: "Escribe un mensaje",
-    Read: "Visto",
-    MessageSendingDisabled: "El envío de mensajes ha sido desactivado",
-    Today: "HOY",
-    Yesterday: "AYER",
-    Save: "GUARDAR",
-    Reset: "RESETEAR",
-    MessageCharacterCountStatus: "{{currentCharCount}} / {{maxCharCount}}",
-    SendMessageTooltip: "Enviar Mensaje",
-    FieldValidationRequiredField: "Campo requerido",
-    FieldValidationInvalidEmail: "Por favor provea una dirección válida de email",
-    PreEngagementDescription: "Comencemos",
-    BotGreeting: "¿Cómo puedo ayudar?",
-
-
-  }
+    MessageCanvasTrayButton: 'Comenzar Nuevo Chat',
+    EntryPointTagline: 'Chatea con nosotros',
+    InvalidPreEngagementMessage:
+      'Los formularios previos al compromiso no se han establecido y son necesarios para iniciar el chat web. Por favor configúrelos ahora en la configuración.',
+    InvalidPreEngagementButton: 'Aprende más',
+    PredefinedChatMessageAuthorName: 'Bot',
+    PredefinedChatMessageBody: '¡Hola! ¿Cómo podemos ayudarte hoy?',
+    InputPlaceHolder: 'Escribe un mensaje',
+    Read: 'Visto',
+    MessageSendingDisabled: 'El envío de mensajes ha sido desactivado',
+    Today: 'HOY',
+    Yesterday: 'AYER',
+    Save: 'GUARDAR',
+    Reset: 'RESETEAR',
+    MessageCharacterCountStatus: '{{currentCharCount}} / {{maxCharCount}}',
+    SendMessageTooltip: 'Enviar Mensaje',
+    FieldValidationRequiredField: 'Campo requerido',
+    FieldValidationInvalidEmail: 'Por favor provea una dirección válida de email',
+    PreEngagementDescription: 'Comencemos',
+    BotGreeting: '¿Cómo puedo ayudar?',
+  },
 };
 
 const memberDisplayOptions = {
@@ -131,7 +136,7 @@ const memberDisplayOptions = {
   yourFriendlyNameOverride: false,
   theirFriendlyNameOverride: false,
   theirDefaultName: 'Guía',
-}
+};
 
 const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {
   switch (helpline) {

--- a/configurations/co-staging.ts
+++ b/configurations/co-staging.ts
@@ -14,7 +14,14 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import {PreEngagementConfig,Translations,Configuration,MapHelplineLanguage,ContactType} from '../types'
+import {
+  PreEngagementConfig,
+  Translations,
+  Configuration,
+  MapHelplineLanguage,
+  ContactType,
+  LocalizedFormAttributes,
+} from '../types';
 
 const accountSid = 'AC76b8bd2798b01b067a1be7f17d36c894';
 const flexFlowSid = 'FOd992a9ef451a263c83c8e556b5393887';
@@ -23,23 +30,26 @@ const captureIp = true;
 const checkOpenHours = false;
 const contactType: ContactType = 'ip';
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: "Comencemos",
-  fields: [
-    {
-      label: 'Hidden Field',
-      type: 'InputField',
-      attributes: {
-        name: '',
-        readOnly: true,
+const preEngagementConfig: LocalizedFormAttributes = {
+  'es-CO': {
+    description: 'Comencemos',
+    fields: [
+      {
+        label: 'Hidden Field',
+        type: 'InputField',
+        attributes: {
+          name: '',
+          readOnly: true,
+        },
       },
-    },
-  ],
-  submitLabel: 'Comenzar Nuevo Chat!',
+    ],
+    submitLabel: 'Comenzar Nuevo Chat!',
+  },
 };
 
 const closedHours: PreEngagementConfig = {
-  description: "Por el momento no estamos atendiendo. Nuestros horarios de atención son de Lunes a Viernes de 8am a 5pm.",
+  description:
+    'Por el momento no estamos atendiendo. Nuestros horarios de atención son de Lunes a Viernes de 8am a 5pm.',
   fields: [
     {
       label: 'Hidden Field',
@@ -51,11 +61,10 @@ const closedHours: PreEngagementConfig = {
       },
     },
   ],
-
 };
 
 const holidayHours: PreEngagementConfig = {
-  description: "Lo siento, no atendemos durante días festivos. ¡Vuelve a escribirnos en el siguiente día hábil!",
+  description: 'Lo siento, no atendemos durante días festivos. ¡Vuelve a escribirnos en el siguiente día hábil!',
   fields: [
     {
       label: 'Hidden Field',
@@ -68,8 +77,6 @@ const holidayHours: PreEngagementConfig = {
     },
   ],
 };
-
-
 
 const translations: Translations = {
   'en-US': {
@@ -83,33 +90,34 @@ const translations: Translations = {
     MessageCanvasTrayButton: 'Start New Chat',
   },
   'es-CO': {
-    WelcomeMessage: "¡Bienvenido a Te Guío!",
+    WelcomeMessage: '¡Bienvenido a Te Guío!',
     MessageCanvasTrayContent: '',
     MessageInputDisabledReasonHold:
-      "Muchas gracias por la información. Lo transferiremos ahora. Por favor espere for un guía.",
+      'Muchas gracias por la información. Lo transferiremos ahora. Por favor espere for un guía.',
     AutoFirstMessage: 'Nuevo contacto del webchat de',
-    TypingIndicator: "{0} está escribiendo ... ",
+    TypingIndicator: '{0} está escribiendo ... ',
     StartChat: 'Comienza a Chatear!',
-    MessageCanvasTrayButton: "Comenzar Nuevo Chat",
-    EntryPointTagline: "Chatea con nosotros",
-    InvalidPreEngagementMessage: "Los formularios previos al compromiso no se han establecido y son necesarios para iniciar el chat web. Por favor configúrelos ahora en la configuración.",
-    InvalidPreEngagementButton: "Aprende más",
-    PredefinedChatMessageAuthorName: "Bot",
-    PredefinedChatMessageBody: "¡Hola! ¿Cómo podemos ayudarte hoy?",
-    InputPlaceHolder: "Escribe un mensaje",
-    Read: "Visto",
-    MessageSendingDisabled: "El envío de mensajes ha sido desactivado",
-    Today: "HOY",
-    Yesterday: "AYER",
-    Save: "GUARDAR",
-    Reset: "RESETEAR",
-    MessageCharacterCountStatus: "{{currentCharCount}} / {{maxCharCount}}",
-    SendMessageTooltip: "Enviar Mensaje",
-    FieldValidationRequiredField: "Campo requerido",
-    FieldValidationInvalidEmail: "Por favor provea una dirección válida de email",
-    PreEngagementDescription: "Comencemos",
-    BotGreeting: "¿Cómo puedo ayudar?",
-  }
+    MessageCanvasTrayButton: 'Comenzar Nuevo Chat',
+    EntryPointTagline: 'Chatea con nosotros',
+    InvalidPreEngagementMessage:
+      'Los formularios previos al compromiso no se han establecido y son necesarios para iniciar el chat web. Por favor configúrelos ahora en la configuración.',
+    InvalidPreEngagementButton: 'Aprende más',
+    PredefinedChatMessageAuthorName: 'Bot',
+    PredefinedChatMessageBody: '¡Hola! ¿Cómo podemos ayudarte hoy?',
+    InputPlaceHolder: 'Escribe un mensaje',
+    Read: 'Visto',
+    MessageSendingDisabled: 'El envío de mensajes ha sido desactivado',
+    Today: 'HOY',
+    Yesterday: 'AYER',
+    Save: 'GUARDAR',
+    Reset: 'RESETEAR',
+    MessageCharacterCountStatus: '{{currentCharCount}} / {{maxCharCount}}',
+    SendMessageTooltip: 'Enviar Mensaje',
+    FieldValidationRequiredField: 'Campo requerido',
+    FieldValidationInvalidEmail: 'Por favor provea una dirección válida de email',
+    PreEngagementDescription: 'Comencemos',
+    BotGreeting: '¿Cómo puedo ayudar?',
+  },
 };
 
 const memberDisplayOptions = {
@@ -117,7 +125,7 @@ const memberDisplayOptions = {
   yourFriendlyNameOverride: false,
   theirFriendlyNameOverride: false,
   theirDefaultName: 'Guía',
-}
+};
 
 const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {
   switch (helpline) {
@@ -138,5 +146,5 @@ export const config: Configuration = {
   mapHelplineLanguage,
   memberDisplayOptions,
   captureIp,
-  contactType
+  contactType,
 };

--- a/configurations/co-staging.ts
+++ b/configurations/co-staging.ts
@@ -14,7 +14,14 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
+import {
+  PreEngagementConfig,
+  Translations,
+  Configuration,
+  MapHelplineLanguage,
+  ContactType,
+  LocalizedFormAttributes,
+} from '../types';
 
 const accountSid = 'AC76b8bd2798b01b067a1be7f17d36c894';
 const flexFlowSid = 'FOd992a9ef451a263c83c8e556b5393887';
@@ -23,19 +30,21 @@ const captureIp = true;
 const checkOpenHours = false;
 const contactType: ContactType = 'ip';
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: 'Comencemos',
-  fields: [
-    {
-      label: 'Hidden Field',
-      type: 'InputField',
-      attributes: {
-        name: '',
-        readOnly: true,
+const preEngagementConfig: LocalizedFormAttributes = {
+  'es-CO': {
+    description: 'Comencemos',
+    fields: [
+      {
+        label: 'Hidden Field',
+        type: 'InputField',
+        attributes: {
+          name: '',
+          readOnly: true,
+        },
       },
-    },
-  ],
-  submitLabel: 'Comenzar Nuevo Chat!',
+    ],
+    submitLabel: 'Comenzar Nuevo Chat!',
+  },
 };
 
 const closedHours: PreEngagementConfig = {

--- a/configurations/co-staging.ts
+++ b/configurations/co-staging.ts
@@ -14,14 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import {
-  PreEngagementConfig,
-  Translations,
-  Configuration,
-  MapHelplineLanguage,
-  ContactType,
-  LocalizedFormAttributes,
-} from '../types';
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
 
 const accountSid = 'AC76b8bd2798b01b067a1be7f17d36c894';
 const flexFlowSid = 'FOd992a9ef451a263c83c8e556b5393887';
@@ -30,21 +23,19 @@ const captureIp = true;
 const checkOpenHours = false;
 const contactType: ContactType = 'ip';
 
-const preEngagementConfig: LocalizedFormAttributes = {
-  'es-CO': {
-    description: 'Comencemos',
-    fields: [
-      {
-        label: 'Hidden Field',
-        type: 'InputField',
-        attributes: {
-          name: '',
-          readOnly: true,
-        },
+const preEngagementConfig: PreEngagementConfig = {
+  description: 'Comencemos',
+  fields: [
+    {
+      label: 'Hidden Field',
+      type: 'InputField',
+      attributes: {
+        name: '',
+        readOnly: true,
       },
-    ],
-    submitLabel: 'Comenzar Nuevo Chat!',
-  },
+    },
+  ],
+  submitLabel: 'Comenzar Nuevo Chat!',
 };
 
 const closedHours: PreEngagementConfig = {

--- a/configurations/e2e-development.ts
+++ b/configurations/e2e-development.ts
@@ -14,14 +14,13 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
+import { Translations, Configuration, MapHelplineLanguage, ContactType, LocalizedFormAttributes } from '../types';
 
 const accountSid = 'AC6a65d4fbbc731e64e1c94e9806675c3b';
 const flexFlowSid = 'FOfce25fd1dff726dcdae2899de86de6c5';
 const defaultLanguage = 'en-US';
 const captureIp = true;
 const contactType: ContactType = 'ip';
-
 
 const translations: Translations = {
   'en-US': {
@@ -40,19 +39,21 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: "Let's get started",
-  fields: [
-    {
-      label: 'Hidden Field',
-      type: 'InputField',
-      attributes: {
-        name: '',
-        readOnly: true,
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-US': {
+    description: "Let's get started",
+    fields: [
+      {
+        label: 'Hidden Field',
+        type: 'InputField',
+        attributes: {
+          name: '',
+          readOnly: true,
+        },
       },
-    },
-  ],
-  submitLabel: 'Start Chat!',
+    ],
+    submitLabel: 'Start Chat!',
+  },
 };
 
 const memberDisplayOptions = {
@@ -78,5 +79,5 @@ export const config: Configuration = {
   mapHelplineLanguage,
   memberDisplayOptions,
   captureIp,
-  contactType
+  contactType,
 };

--- a/configurations/e2e-development.ts
+++ b/configurations/e2e-development.ts
@@ -14,7 +14,14 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
+import {
+  PreEngagementConfig,
+  Translations,
+  Configuration,
+  MapHelplineLanguage,
+  ContactType,
+  LocalizedFormAttributes,
+} from '../types';
 
 const accountSid = 'AC6a65d4fbbc731e64e1c94e9806675c3b';
 const flexFlowSid = 'FOfce25fd1dff726dcdae2899de86de6c5';
@@ -39,19 +46,21 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: "Let's get started",
-  fields: [
-    {
-      label: 'Hidden Field',
-      type: 'InputField',
-      attributes: {
-        name: '',
-        readOnly: true,
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-US': {
+    description: "Let's get started",
+    fields: [
+      {
+        label: 'Hidden Field',
+        type: 'InputField',
+        attributes: {
+          name: '',
+          readOnly: true,
+        },
       },
-    },
-  ],
-  submitLabel: 'Start Chat!',
+    ],
+    submitLabel: 'Start Chat!',
+  },
 };
 
 const memberDisplayOptions = {

--- a/configurations/e2e-development.ts
+++ b/configurations/e2e-development.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { Translations, Configuration, MapHelplineLanguage, ContactType, LocalizedFormAttributes } from '../types';
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
 
 const accountSid = 'AC6a65d4fbbc731e64e1c94e9806675c3b';
 const flexFlowSid = 'FOfce25fd1dff726dcdae2899de86de6c5';
@@ -39,21 +39,19 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: LocalizedFormAttributes = {
-  'en-US': {
-    description: "Let's get started",
-    fields: [
-      {
-        label: 'Hidden Field',
-        type: 'InputField',
-        attributes: {
-          name: '',
-          readOnly: true,
-        },
+const preEngagementConfig: PreEngagementConfig = {
+  description: "Let's get started",
+  fields: [
+    {
+      label: 'Hidden Field',
+      type: 'InputField',
+      attributes: {
+        name: '',
+        readOnly: true,
       },
-    ],
-    submitLabel: 'Start Chat!',
-  },
+    },
+  ],
+  submitLabel: 'Start Chat!',
 };
 
 const memberDisplayOptions = {

--- a/configurations/et-staging.ts
+++ b/configurations/et-staging.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
+import { Translations, Configuration, MapHelplineLanguage, ContactType, LocalizedFormAttributes } from '../types';
 
 const accountSid = 'ACfd932bd76669f9cc2145e67e6c3e03ea';
 const flexFlowSid = 'FOe37919dd07e25959ef5c480519270d91';
@@ -31,34 +31,36 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: "Let's get started",
-  fields: [
-    {
-      label: 'Hidden Field',
-      type: 'InputField',
-      attributes: {
-        name: '',
-        readOnly: true,
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-US': {
+    description: "Let's get started",
+    fields: [
+      {
+        label: 'Hidden Field',
+        type: 'InputField',
+        attributes: {
+          name: '',
+          readOnly: true,
+        },
       },
-    },
-  ],
-  submitLabel: 'Start Chat!',
+    ],
+    submitLabel: 'Start Chat!',
+  },
 };
 
-const mapHelplineLanguage: MapHelplineLanguage = helpline => {
+const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {
   switch (helpline) {
     default:
       return defaultLanguage;
   }
-}
+};
 
 const memberDisplayOptions = {
   yourDefaultName: 'You',
   yourFriendlyNameOverride: false,
   theirFriendlyNameOverride: false,
   theirDefaultName: 'Adama Helpline Counsellor',
-}
+};
 
 export const config: Configuration = {
   accountSid,
@@ -69,5 +71,5 @@ export const config: Configuration = {
   mapHelplineLanguage,
   memberDisplayOptions,
   captureIp,
-  contactType
+  contactType,
 };

--- a/configurations/et-staging.ts
+++ b/configurations/et-staging.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { Translations, Configuration, MapHelplineLanguage, ContactType, LocalizedFormAttributes } from '../types';
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
 
 const accountSid = 'ACfd932bd76669f9cc2145e67e6c3e03ea';
 const flexFlowSid = 'FOe37919dd07e25959ef5c480519270d91';
@@ -31,21 +31,19 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: LocalizedFormAttributes = {
-  'en-US': {
-    description: "Let's get started",
-    fields: [
-      {
-        label: 'Hidden Field',
-        type: 'InputField',
-        attributes: {
-          name: '',
-          readOnly: true,
-        },
+const preEngagementConfig: PreEngagementConfig = {
+  description: "Let's get started",
+  fields: [
+    {
+      label: 'Hidden Field',
+      type: 'InputField',
+      attributes: {
+        name: '',
+        readOnly: true,
       },
-    ],
-    submitLabel: 'Start Chat!',
-  },
+    },
+  ],
+  submitLabel: 'Start Chat!',
 };
 
 const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {

--- a/configurations/et-staging.ts
+++ b/configurations/et-staging.ts
@@ -14,7 +14,14 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
+import {
+  PreEngagementConfig,
+  Translations,
+  Configuration,
+  MapHelplineLanguage,
+  ContactType,
+  LocalizedFormAttributes,
+} from '../types';
 
 const accountSid = 'ACfd932bd76669f9cc2145e67e6c3e03ea';
 const flexFlowSid = 'FOe37919dd07e25959ef5c480519270d91';
@@ -31,19 +38,21 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: "Let's get started",
-  fields: [
-    {
-      label: 'Hidden Field',
-      type: 'InputField',
-      attributes: {
-        name: '',
-        readOnly: true,
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-US': {
+    description: "Let's get started",
+    fields: [
+      {
+        label: 'Hidden Field',
+        type: 'InputField',
+        attributes: {
+          name: '',
+          readOnly: true,
+        },
       },
-    },
-  ],
-  submitLabel: 'Start Chat!',
+    ],
+    submitLabel: 'Start Chat!',
+  },
 };
 
 const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {

--- a/configurations/hu-staging.ts
+++ b/configurations/hu-staging.ts
@@ -14,7 +14,14 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
+import {
+  PreEngagementConfig,
+  Translations,
+  Configuration,
+  MapHelplineLanguage,
+  ContactType,
+  LocalizedFormAttributes,
+} from '../types';
 
 const accountSid = 'ACbdbee34ef7d099e71cf095d540ff3270';
 const flexFlowSid = 'FO9d20dbe99abbc3b9ad7709f961b0fe95';
@@ -24,70 +31,67 @@ const checkOpenHours = false;
 const contactType: ContactType = 'ip';
 
 const translations: Translations = {
-    'en-US': {
-      MessageInputDisabledReasonHold:
-        "We'll transfer you now. Please hold for a counsellor.",
-      EntryPointTagLine: 'Chat with us',
-      PreEngagementDescription: "Let's get started",
-      Today: 'Today',
-      InputPlaceHolder: 'Type Message',
-      WelcomeMessage: 'Welcome to Kék Vonal!',
-      Yesterday: 'Yesterday',
-      TypingIndicator: 'Counselor is typing',
-      MessageCanvasTrayButton: 'Start New Chat',
-      MessageCanvasTrayContent: '',
-      AutoFirstMessage: 'Incoming webchat contact from',
-      StartChat: 'Start Chat!',
-    },
-    'hu-HU': {
-      MessageInputDisabledReasonHold:
-        'Továbbítunk egy ügyelőhöz, akivel beszélgetni tudsz.',
-      EntryPointTagLine: 'Csetelj velünk',
-      PreEngagementDescription: '',
-      Today: 'Ma',
-      InputPlaceHolder: 'Taipeni ilyashi',
-      WelcomeMessage: 'Szia, ez itt a Kék Vonal!',
-      Yesterday: 'Tegnap',
-      TypingIndicator: 'gépelés...',
-      MessageCanvasTrayButton: 'Chat indítása',
-      MessageCanvasTrayContent: '',
-      AutoFirstMessage: 'Bejövő chat',
-      StartChat: 'Chat indítása!',
-    },
-    'ukr-HU': {
-      MessageInputDisabledReasonHold:
-        'Зв\'яжемо тебе із нашим консультантом, з яким ти зможеш поговорити.',
-      EntryPointTagLine: 'Поспілкуйся з нами в чаті',
-      PreEngagementDescription: '',
-      Today: 'Сьогодні',
-      InputPlaceHolder: "Введіть повідомлення",
-      WelcomeMessage: 'Привіт, це Блакитна Лінія!',
-      Yesterday: 'вчора',
-      TypingIndicator: 'набір тексту...',
-      MessageCanvasTrayButton: 'Почати чат',
-      MessageCanvasTrayContent: '',
-      AutoFirstMessage: 'Вхідний чат',
-      StartChat: 'Почати чат!',
-    },
-    'ru-HU': {
-      MessageInputDisabledReasonHold:
-        "Свяжем тебя с нашим консультантом, с которым ты сможешь поговорить.",
-      EntryPointTagLine: 'Пообщайся с нами в чате',
-      PreEngagementDescription: 'Давайте начнем',
-      Today: 'Сегодня',
-      InputPlaceHolder: 'Введите сообщение',
-      WelcomeMessage: 'Привет, это Синяя Линия!',
-      Yesterday: 'Вчерашний день',
-      TypingIndicator: "набор текста...",
-      MessageCanvasTrayButton: 'Привет, это Синяя Линия!',
-      MessageCanvasTrayContent: '',
-      AutoFirstMessage: 'Входящий чат',
-      StartChat: 'Начать чат!',
-    }
-  };
+  'en-US': {
+    MessageInputDisabledReasonHold: "We'll transfer you now. Please hold for a counsellor.",
+    EntryPointTagLine: 'Chat with us',
+    PreEngagementDescription: "Let's get started",
+    Today: 'Today',
+    InputPlaceHolder: 'Type Message',
+    WelcomeMessage: 'Welcome to Kék Vonal!',
+    Yesterday: 'Yesterday',
+    TypingIndicator: 'Counselor is typing',
+    MessageCanvasTrayButton: 'Start New Chat',
+    MessageCanvasTrayContent: '',
+    AutoFirstMessage: 'Incoming webchat contact from',
+    StartChat: 'Start Chat!',
+  },
+  'hu-HU': {
+    MessageInputDisabledReasonHold: 'Továbbítunk egy ügyelőhöz, akivel beszélgetni tudsz.',
+    EntryPointTagLine: 'Csetelj velünk',
+    PreEngagementDescription: '',
+    Today: 'Ma',
+    InputPlaceHolder: 'Taipeni ilyashi',
+    WelcomeMessage: 'Szia, ez itt a Kék Vonal!',
+    Yesterday: 'Tegnap',
+    TypingIndicator: 'gépelés...',
+    MessageCanvasTrayButton: 'Chat indítása',
+    MessageCanvasTrayContent: '',
+    AutoFirstMessage: 'Bejövő chat',
+    StartChat: 'Chat indítása!',
+  },
+  'ukr-HU': {
+    MessageInputDisabledReasonHold: "Зв'яжемо тебе із нашим консультантом, з яким ти зможеш поговорити.",
+    EntryPointTagLine: 'Поспілкуйся з нами в чаті',
+    PreEngagementDescription: '',
+    Today: 'Сьогодні',
+    InputPlaceHolder: 'Введіть повідомлення',
+    WelcomeMessage: 'Привіт, це Блакитна Лінія!',
+    Yesterday: 'вчора',
+    TypingIndicator: 'набір тексту...',
+    MessageCanvasTrayButton: 'Почати чат',
+    MessageCanvasTrayContent: '',
+    AutoFirstMessage: 'Вхідний чат',
+    StartChat: 'Почати чат!',
+  },
+  'ru-HU': {
+    MessageInputDisabledReasonHold: 'Свяжем тебя с нашим консультантом, с которым ты сможешь поговорить.',
+    EntryPointTagLine: 'Пообщайся с нами в чате',
+    PreEngagementDescription: 'Давайте начнем',
+    Today: 'Сегодня',
+    InputPlaceHolder: 'Введите сообщение',
+    WelcomeMessage: 'Привет, это Синяя Линия!',
+    Yesterday: 'Вчерашний день',
+    TypingIndicator: 'набор текста...',
+    MessageCanvasTrayButton: 'Привет, это Синяя Линия!',
+    MessageCanvasTrayContent: '',
+    AutoFirstMessage: 'Входящий чат',
+    StartChat: 'Начать чат!',
+  },
+};
 
-const preEngagementConfig: PreEngagementConfig = {
-    description: "",
+const preEngagementConfig: LocalizedFormAttributes = {
+  'ukr-HU': {
+    description: '',
     fields: [
       {
         label: '',
@@ -107,15 +111,17 @@ const preEngagementConfig: PreEngagementConfig = {
             value: 'ru-HU',
             label: 'Русский',
             selected: false,
-          }
+          },
         ],
       },
     ],
     submitLabel: 'Start',
-  };
+  },
+};
 
-  const closedHours: PreEngagementConfig = {
-  description: "Привіт, це Kék Vonal. Наразі усі наші оператори зайняті. Спілкуватися українською чи російською мовами ти можеш у вівторок і четвер з 16:00 до 20:00. Чекаємо твого дзвінка! \n\nПривет, это Kék Vonal. На данный момент все наши операторы заняты. Общаться на украинском или русском языке ты можешь во вторник и четверг с 16:00 до 20:00. Ждем твоего звонка!",
+const closedHours: PreEngagementConfig = {
+  description:
+    'Привіт, це Kék Vonal. Наразі усі наші оператори зайняті. Спілкуватися українською чи російською мовами ти можеш у вівторок і четвер з 16:00 до 20:00. Чекаємо твого дзвінка! \n\nПривет, это Kék Vonal. На данный момент все наши операторы заняты. Общаться на украинском или русском языке ты можешь во вторник и четверг с 16:00 до 20:00. Ждем твоего звонка!',
   fields: [
     {
       label: 'Hidden Field',
@@ -127,22 +133,21 @@ const preEngagementConfig: PreEngagementConfig = {
       },
     },
   ],
-
 };
 
-const mapHelplineLanguage: MapHelplineLanguage = helpline => {
+const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {
   switch (helpline) {
     default:
       return defaultLanguage;
   }
-}
+};
 
 const memberDisplayOptions = {
   yourDefaultName: 'You',
   yourFriendlyNameOverride: false,
   theirFriendlyNameOverride: false,
   theirDefaultName: 'Kék Vonal',
-}
+};
 
 export const config: Configuration = {
   accountSid,
@@ -155,5 +160,5 @@ export const config: Configuration = {
   captureIp,
   checkOpenHours,
   closedHours,
-  contactType
+  contactType,
 };

--- a/configurations/hu-staging.ts
+++ b/configurations/hu-staging.ts
@@ -14,14 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import {
-  PreEngagementConfig,
-  Translations,
-  Configuration,
-  MapHelplineLanguage,
-  ContactType,
-  LocalizedFormAttributes,
-} from '../types';
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
 
 const accountSid = 'ACbdbee34ef7d099e71cf095d540ff3270';
 const flexFlowSid = 'FO9d20dbe99abbc3b9ad7709f961b0fe95';
@@ -89,34 +82,32 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: LocalizedFormAttributes = {
-  'ukr-HU': {
-    description: '',
-    fields: [
-      {
-        label: '',
-        type: 'SelectItem',
-        attributes: {
-          name: 'language',
-          required: true,
-          readOnly: false,
-        },
-        options: [
-          {
-            value: 'ukr-HU',
-            label: 'Українська',
-            selected: false,
-          },
-          {
-            value: 'ru-HU',
-            label: 'Русский',
-            selected: false,
-          },
-        ],
+const preEngagementConfig: PreEngagementConfig = {
+  description: '',
+  fields: [
+    {
+      label: '',
+      type: 'SelectItem',
+      attributes: {
+        name: 'language',
+        required: true,
+        readOnly: false,
       },
-    ],
-    submitLabel: 'Start',
-  },
+      options: [
+        {
+          value: 'ukr-HU',
+          label: 'Українська',
+          selected: false,
+        },
+        {
+          value: 'ru-HU',
+          label: 'Русский',
+          selected: false,
+        },
+      ],
+    },
+  ],
+  submitLabel: 'Start',
 };
 
 const closedHours: PreEngagementConfig = {

--- a/configurations/hu-staging.ts
+++ b/configurations/hu-staging.ts
@@ -14,7 +14,14 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
+import {
+  PreEngagementConfig,
+  Translations,
+  Configuration,
+  MapHelplineLanguage,
+  ContactType,
+  LocalizedFormAttributes,
+} from '../types';
 
 const accountSid = 'ACbdbee34ef7d099e71cf095d540ff3270';
 const flexFlowSid = 'FO9d20dbe99abbc3b9ad7709f961b0fe95';
@@ -82,32 +89,34 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: '',
-  fields: [
-    {
-      label: '',
-      type: 'SelectItem',
-      attributes: {
-        name: 'language',
-        required: true,
-        readOnly: false,
+const preEngagementConfig: LocalizedFormAttributes = {
+  'ukr-HU': {
+    description: '',
+    fields: [
+      {
+        label: '',
+        type: 'SelectItem',
+        attributes: {
+          name: 'language',
+          required: true,
+          readOnly: false,
+        },
+        options: [
+          {
+            value: 'ukr-HU',
+            label: 'Українська',
+            selected: false,
+          },
+          {
+            value: 'ru-HU',
+            label: 'Русский',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: 'ukr-HU',
-          label: 'Українська',
-          selected: false,
-        },
-        {
-          value: 'ru-HU',
-          label: 'Русский',
-          selected: false,
-        },
-      ],
-    },
-  ],
-  submitLabel: 'Start',
+    ],
+    submitLabel: 'Start',
+  },
 };
 
 const closedHours: PreEngagementConfig = {

--- a/configurations/jm-staging.ts
+++ b/configurations/jm-staging.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { Translations, Configuration, MapHelplineLanguage, ContactType, LocalizedFormAttributes } from '../types';
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
 
 const accountSid = 'ACbc27263c18e621f3deb57cf1998a4e04';
 const flexFlowSid = 'FOfe4a6c70afb6460dff8a7c2b1503b7aa';
@@ -32,24 +32,22 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: LocalizedFormAttributes = {
-  'en-US': {
-    description:
-      'Thank you for contacting SafeSpot. To chat with a counsellor, please type your name and select the Start Chat button.',
-    fields: [
-      {
-        type: 'InputItem',
-        label: 'What is your name?',
-        attributes: {
-          name: 'friendlyName',
-          type: 'text',
-          placeholder: 'Guest',
-          required: true,
-        },
+const preEngagementConfig: PreEngagementConfig = {
+  description:
+    'Thank you for contacting SafeSpot. To chat with a counsellor, please type your name and select the Start Chat button.',
+  fields: [
+    {
+      type: 'InputItem',
+      label: 'What is your name?',
+      attributes: {
+        name: 'friendlyName',
+        type: 'text',
+        placeholder: 'Guest',
+        required: true,
       },
-    ],
-    submitLabel: 'Start Chat!',
-  },
+    },
+  ],
+  submitLabel: 'Start Chat!',
 };
 
 const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {

--- a/configurations/jm-staging.ts
+++ b/configurations/jm-staging.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
+import { Translations, Configuration, MapHelplineLanguage, ContactType, LocalizedFormAttributes } from '../types';
 
 const accountSid = 'ACbc27263c18e621f3deb57cf1998a4e04';
 const flexFlowSid = 'FOfe4a6c70afb6460dff8a7c2b1503b7aa';
@@ -26,43 +26,45 @@ const translations: Translations = {
   'en-US': {
     WelcomeMessage: 'Welcome to SafeSpot',
     MessageCanvasTrayContent: '',
-    MessageInputDisabledReasonHold: 
+    MessageInputDisabledReasonHold:
       "Thank you very much for this information. We'll transfer you now. Please hold for a counsellor.",
     AutoFirstMessage: 'Incoming webchat contact from',
   },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: "Thank you for contacting SafeSpot. To chat with a counsellor, please type your name and select the Start Chat button.",
-  fields:
-    [
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-US': {
+    description:
+      'Thank you for contacting SafeSpot. To chat with a counsellor, please type your name and select the Start Chat button.',
+    fields: [
       {
-        type: "InputItem",
-        label: "What is your name?",
+        type: 'InputItem',
+        label: 'What is your name?',
         attributes: {
-          name: "friendlyName",
-          type: "text",
-          placeholder: "Guest",
+          name: 'friendlyName',
+          type: 'text',
+          placeholder: 'Guest',
           required: true,
-        }
-      }
+        },
+      },
     ],
-  submitLabel: "Start Chat!"
+    submitLabel: 'Start Chat!',
+  },
 };
 
-const mapHelplineLanguage: MapHelplineLanguage = helpline => {
+const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {
   switch (helpline) {
     default:
       return defaultLanguage;
   }
-}
+};
 
 const memberDisplayOptions = {
   yourDefaultName: 'You',
   yourFriendlyNameOverride: false,
   theirFriendlyNameOverride: false,
   theirDefaultName: 'SafeSpot Counsellor',
-}
+};
 
 export const config: Configuration = {
   accountSid,
@@ -73,5 +75,5 @@ export const config: Configuration = {
   mapHelplineLanguage,
   memberDisplayOptions,
   captureIp,
-  contactType
+  contactType,
 };

--- a/configurations/jm-staging.ts
+++ b/configurations/jm-staging.ts
@@ -14,7 +14,14 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
+import {
+  PreEngagementConfig,
+  Translations,
+  Configuration,
+  MapHelplineLanguage,
+  ContactType,
+  LocalizedFormAttributes,
+} from '../types';
 
 const accountSid = 'ACbc27263c18e621f3deb57cf1998a4e04';
 const flexFlowSid = 'FOfe4a6c70afb6460dff8a7c2b1503b7aa';
@@ -32,22 +39,24 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description:
-    'Thank you for contacting SafeSpot. To chat with a counsellor, please type your name and select the Start Chat button.',
-  fields: [
-    {
-      type: 'InputItem',
-      label: 'What is your name?',
-      attributes: {
-        name: 'friendlyName',
-        type: 'text',
-        placeholder: 'Guest',
-        required: true,
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-US': {
+    description:
+      'Thank you for contacting SafeSpot. To chat with a counsellor, please type your name and select the Start Chat button.',
+    fields: [
+      {
+        type: 'InputItem',
+        label: 'What is your name?',
+        attributes: {
+          name: 'friendlyName',
+          type: 'text',
+          placeholder: 'Guest',
+          required: true,
+        },
       },
-    },
-  ],
-  submitLabel: 'Start Chat!',
+    ],
+    submitLabel: 'Start Chat!',
+  },
 };
 
 const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {

--- a/configurations/mt-staging.ts
+++ b/configurations/mt-staging.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { Translations, Configuration, MapHelplineLanguage, ContactType, LocalizedFormAttributes } from '../types';
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
 
 const accountSid = 'ACfb0ccf10880289d67f5c4e85ae26402b';
 const flexFlowSid = 'FOd69e1f3020fd621d4bd9d4be833d8a19';
@@ -67,49 +67,47 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: LocalizedFormAttributes = {
-  'en-MT': {
-    description: "Let's get started",
-    fields: [
-      {
-        label: 'Select your language',
-        type: 'SelectItem',
-        attributes: {
-          name: 'language',
-          required: true,
-          readOnly: false,
-        },
-        options: [
-          {
-            value: 'en-MT',
-            label: '1. English',
-            selected: true,
-          },
-          {
-            value: 'mt-MT',
-            label: '2. Maltese',
-            selected: false,
-          },
-          {
-            value: 'ukr-MT',
-            label: '3. Ukrainian',
-            selected: false,
-          },
-        ],
+const preEngagementConfig: PreEngagementConfig = {
+  description: "Let's get started",
+  fields: [
+    {
+      label: 'Select your language',
+      type: 'SelectItem',
+      attributes: {
+        name: 'language',
+        required: true,
+        readOnly: false,
       },
-      {
-        type: 'InputItem',
-        label: 'Nickname/Laqam/нікнейм',
-        attributes: {
-          name: 'nickname',
-          type: 'text',
-          placeholder: "Guest's name. Please enter only your name.",
-          required: true,
+      options: [
+        {
+          value: 'en-MT',
+          label: '1. English',
+          selected: true,
         },
+        {
+          value: 'mt-MT',
+          label: '2. Maltese',
+          selected: false,
+        },
+        {
+          value: 'ukr-MT',
+          label: '3. Ukrainian',
+          selected: false,
+        },
+      ],
+    },
+    {
+      type: 'InputItem',
+      label: 'Nickname/Laqam/нікнейм',
+      attributes: {
+        name: 'nickname',
+        type: 'text',
+        placeholder: "Guest's name. Please enter only your name.",
+        required: true,
       },
-    ],
-    submitLabel: 'Start Chat!',
-  },
+    },
+  ],
+  submitLabel: 'Start Chat!',
 };
 
 const memberDisplayOptions = {

--- a/configurations/mt-staging.ts
+++ b/configurations/mt-staging.ts
@@ -14,13 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import {
-  PreEngagementConfig,
-  Translations,
-  Configuration,
-  MapHelplineLanguage,
-  ContactType
-} from '../types';
+import { Translations, Configuration, MapHelplineLanguage, ContactType, LocalizedFormAttributes } from '../types';
 
 const accountSid = 'ACfb0ccf10880289d67f5c4e85ae26402b';
 const flexFlowSid = 'FOd69e1f3020fd621d4bd9d4be833d8a19';
@@ -30,8 +24,7 @@ const contactType: ContactType = 'ip';
 
 const translations: Translations = {
   'en-MT': {
-    MessageInputDisabledReasonHold:
-      "We'll transfer you now. Please hold for a support mentor.",
+    MessageInputDisabledReasonHold: "We'll transfer you now. Please hold for a support mentor.",
     EntryPointTagLine: 'Chat with us',
     PreEngagementDescription: "Let's get started",
     Today: 'Today',
@@ -45,10 +38,9 @@ const translations: Translations = {
     StartChat: 'Start Chat!',
   },
   'mt-MT': {
-    MessageInputDisabledReasonHold:
-      "Ha nittrasferuk lil wieħed mis-Support Mentors tagħna.",
+    MessageInputDisabledReasonHold: 'Ha nittrasferuk lil wieħed mis-Support Mentors tagħna.',
     EntryPointTagLine: 'Chat magħna',
-    PreEngagementDescription: "Ejja nibdew",
+    PreEngagementDescription: 'Ejja nibdew',
     Today: 'Illum',
     InputPlaceHolder: 'Tip Messaġġ',
     WelcomeMessage: 'Merħba lil Kellimni!',
@@ -60,63 +52,64 @@ const translations: Translations = {
     StartChat: 'Ibda Chat!',
   },
   'ukr-MT': {
-      MessageInputDisabledReasonHold:
-        'Зв\'яжемо тебе із нашим консультантом, з яким ти зможеш поговорити.',
-      EntryPointTagLine: 'Поспілкуйся з нами в чаті',
-      PreEngagementDescription: 'Давайте розпочнемо',
-      Today: 'Сьогодні',
-      InputPlaceHolder: "Введіть повідомлення",
-      WelcomeMessage: 'Привіт, це Блакитна Лінія!',
-      Yesterday: 'вчора',
-      TypingIndicator: 'набір тексту...',
-      MessageCanvasTrayButton: 'Почати чат',
-      MessageCanvasTrayContent: '',
-      AutoFirstMessage: 'Вхідний чат',
-      StartChat: 'Почати чат!',
+    MessageInputDisabledReasonHold: "Зв'яжемо тебе із нашим консультантом, з яким ти зможеш поговорити.",
+    EntryPointTagLine: 'Поспілкуйся з нами в чаті',
+    PreEngagementDescription: 'Давайте розпочнемо',
+    Today: 'Сьогодні',
+    InputPlaceHolder: 'Введіть повідомлення',
+    WelcomeMessage: 'Привіт, це Блакитна Лінія!',
+    Yesterday: 'вчора',
+    TypingIndicator: 'набір тексту...',
+    MessageCanvasTrayButton: 'Почати чат',
+    MessageCanvasTrayContent: '',
+    AutoFirstMessage: 'Вхідний чат',
+    StartChat: 'Почати чат!',
   },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: "Let's get started",
-  fields: [
-    {
-      label: 'Select your language',
-      type: 'SelectItem',
-      attributes: {
-        name: 'language',
-        required: true,
-        readOnly: false,
-      },
-      options: [
-        {
-          value: 'en-MT',
-          label: '1. English',
-          selected: true,
-        },
-        {
-          value: 'mt-MT',
-          label: '2. Maltese',
-          selected: false,
-        },
-        {
-          value: 'ukr-MT',
-          label: '3. Ukrainian',
-          selected: false,
-        },
-      ],
-    },
-    {
-        type: "InputItem",
-        label: "Nickname/Laqam/нікнейм",
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-MT': {
+    description: "Let's get started",
+    fields: [
+      {
+        label: 'Select your language',
+        type: 'SelectItem',
         attributes: {
-          name: "nickname",
-          type: "text",
+          name: 'language',
+          required: true,
+          readOnly: false,
+        },
+        options: [
+          {
+            value: 'en-MT',
+            label: '1. English',
+            selected: true,
+          },
+          {
+            value: 'mt-MT',
+            label: '2. Maltese',
+            selected: false,
+          },
+          {
+            value: 'ukr-MT',
+            label: '3. Ukrainian',
+            selected: false,
+          },
+        ],
+      },
+      {
+        type: 'InputItem',
+        label: 'Nickname/Laqam/нікнейм',
+        attributes: {
+          name: 'nickname',
+          type: 'text',
           placeholder: "Guest's name. Please enter only your name.",
           required: true,
-        }
-    },
-  ],
-  submitLabel: 'Start Chat!',
+        },
+      },
+    ],
+    submitLabel: 'Start Chat!',
+  },
 };
 
 const memberDisplayOptions = {
@@ -124,14 +117,14 @@ const memberDisplayOptions = {
   yourFriendlyNameOverride: false,
   theirFriendlyNameOverride: false,
   theirDefaultName: 'Support Mentor',
-}
+};
 
-const mapHelplineLanguage: MapHelplineLanguage = helpline => {
+const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {
   switch (helpline) {
     default:
       return defaultLanguage;
   }
-}
+};
 
 export const config: Configuration = {
   accountSid,
@@ -141,5 +134,6 @@ export const config: Configuration = {
   preEngagementConfig,
   mapHelplineLanguage,
   memberDisplayOptions,
-  captureIp,contactType
+  captureIp,
+  contactType,
 };

--- a/configurations/mt-staging.ts
+++ b/configurations/mt-staging.ts
@@ -14,7 +14,14 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
+import {
+  PreEngagementConfig,
+  Translations,
+  Configuration,
+  MapHelplineLanguage,
+  ContactType,
+  LocalizedFormAttributes,
+} from '../types';
 
 const accountSid = 'ACfb0ccf10880289d67f5c4e85ae26402b';
 const flexFlowSid = 'FOd69e1f3020fd621d4bd9d4be833d8a19';
@@ -67,47 +74,49 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: "Let's get started",
-  fields: [
-    {
-      label: 'Select your language',
-      type: 'SelectItem',
-      attributes: {
-        name: 'language',
-        required: true,
-        readOnly: false,
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-MT': {
+    description: "Let's get started",
+    fields: [
+      {
+        label: 'Select your language',
+        type: 'SelectItem',
+        attributes: {
+          name: 'language',
+          required: true,
+          readOnly: false,
+        },
+        options: [
+          {
+            value: 'en-MT',
+            label: '1. English',
+            selected: true,
+          },
+          {
+            value: 'mt-MT',
+            label: '2. Maltese',
+            selected: false,
+          },
+          {
+            value: 'ukr-MT',
+            label: '3. Ukrainian',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: 'en-MT',
-          label: '1. English',
-          selected: true,
+      {
+        type: 'InputItem',
+        label: 'Nickname/Laqam/нікнейм',
+        attributes: {
+          name: 'nickname',
+          type: 'text',
+          placeholder: "Guest's name. Please enter only your name.",
+          required: true,
         },
-        {
-          value: 'mt-MT',
-          label: '2. Maltese',
-          selected: false,
-        },
-        {
-          value: 'ukr-MT',
-          label: '3. Ukrainian',
-          selected: false,
-        },
-      ],
-    },
-    {
-      type: 'InputItem',
-      label: 'Nickname/Laqam/нікнейм',
-      attributes: {
-        name: 'nickname',
-        type: 'text',
-        placeholder: "Guest's name. Please enter only your name.",
-        required: true,
       },
-    },
-  ],
-  submitLabel: 'Start Chat!',
+    ],
+    submitLabel: 'Start Chat!',
+  },
 };
 
 const memberDisplayOptions = {

--- a/configurations/mw-staging.ts
+++ b/configurations/mw-staging.ts
@@ -14,7 +14,14 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
+import {
+  PreEngagementConfig,
+  Translations,
+  Configuration,
+  MapHelplineLanguage,
+  ContactType,
+  LocalizedFormAttributes,
+} from '../types';
 
 const accountSid = 'AC874af45ec4a696d5d4dca07b0036e2bf';
 const flexFlowSid = 'FO7fb4e9816507d650ddc221f27d2d8927';
@@ -31,19 +38,21 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: "Let's get started",
-  fields: [
-    {
-      label: 'Hidden Field',
-      type: 'InputField',
-      attributes: {
-        name: '',
-        readOnly: true,
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-US': {
+    description: "Let's get started",
+    fields: [
+      {
+        label: 'Hidden Field',
+        type: 'InputField',
+        attributes: {
+          name: '',
+          readOnly: true,
+        },
       },
-    },
-  ],
-  submitLabel: 'Start Chat!',
+    ],
+    submitLabel: 'Start Chat!',
+  },
 };
 
 const mapHelplineLanguage: MapHelplineLanguage = (helpline: string) => {

--- a/configurations/mw-staging.ts
+++ b/configurations/mw-staging.ts
@@ -46,19 +46,19 @@ const preEngagementConfig: PreEngagementConfig = {
   submitLabel: 'Start Chat!',
 };
 
-const mapHelplineLanguage: MapHelplineLanguage = helpline => {
+const mapHelplineLanguage: MapHelplineLanguage = (helpline: string) => {
   switch (helpline) {
     default:
       return defaultLanguage;
   }
-}
+};
 
 const memberDisplayOptions = {
   yourDefaultName: 'You',
   yourFriendlyNameOverride: false,
   theirFriendlyNameOverride: false,
   theirDefaultName: 'Tithandizane Counsellor',
-}
+};
 
 export const config: Configuration = {
   accountSid,
@@ -68,5 +68,6 @@ export const config: Configuration = {
   preEngagementConfig,
   mapHelplineLanguage,
   memberDisplayOptions,
-  captureIp,contactType
+  captureIp,
+  contactType,
 };

--- a/configurations/pl-staging.ts
+++ b/configurations/pl-staging.ts
@@ -14,7 +14,14 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
+import {
+  PreEngagementConfig,
+  Translations,
+  Configuration,
+  MapHelplineLanguage,
+  ContactType,
+  LocalizedFormAttributes,
+} from '../types';
 
 const accountSid = 'ACb3da2ab24338c616db45ba3b4afce61a';
 const flexFlowSid = 'FO83947facb0df52ee4849d30275334213';
@@ -32,22 +39,24 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description:
-    'Thank you for contacting Telefon Zaufania. To chat with a counsellor, please type your name and select the Start Chat button.',
-  fields: [
-    {
-      type: 'InputItem',
-      label: 'What is your name?',
-      attributes: {
-        name: 'friendlyName',
-        type: 'text',
-        placeholder: 'Guest',
-        required: true,
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-US': {
+    description:
+      'Thank you for contacting Telefon Zaufania. To chat with a counsellor, please type your name and select the Start Chat button.',
+    fields: [
+      {
+        type: 'InputItem',
+        label: 'What is your name?',
+        attributes: {
+          name: 'friendlyName',
+          type: 'text',
+          placeholder: 'Guest',
+          required: true,
+        },
       },
-    },
-  ],
-  submitLabel: 'Start Chat!',
+    ],
+    submitLabel: 'Start Chat!',
+  },
 };
 
 const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {

--- a/configurations/pl-staging.ts
+++ b/configurations/pl-staging.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { Translations, Configuration, MapHelplineLanguage, ContactType, LocalizedFormAttributes } from '../types';
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
 
 const accountSid = 'ACb3da2ab24338c616db45ba3b4afce61a';
 const flexFlowSid = 'FO83947facb0df52ee4849d30275334213';
@@ -32,24 +32,22 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: LocalizedFormAttributes = {
-  'en-US': {
-    description:
-      'Thank you for contacting Telefon Zaufania. To chat with a counsellor, please type your name and select the Start Chat button.',
-    fields: [
-      {
-        type: 'InputItem',
-        label: 'What is your name?',
-        attributes: {
-          name: 'friendlyName',
-          type: 'text',
-          placeholder: 'Guest',
-          required: true,
-        },
+const preEngagementConfig: PreEngagementConfig = {
+  description:
+    'Thank you for contacting Telefon Zaufania. To chat with a counsellor, please type your name and select the Start Chat button.',
+  fields: [
+    {
+      type: 'InputItem',
+      label: 'What is your name?',
+      attributes: {
+        name: 'friendlyName',
+        type: 'text',
+        placeholder: 'Guest',
+        required: true,
       },
-    ],
-    submitLabel: 'Start Chat!',
-  },
+    },
+  ],
+  submitLabel: 'Start Chat!',
 };
 
 const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {

--- a/configurations/pl-staging.ts
+++ b/configurations/pl-staging.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
+import { Translations, Configuration, MapHelplineLanguage, ContactType, LocalizedFormAttributes } from '../types';
 
 const accountSid = 'ACb3da2ab24338c616db45ba3b4afce61a';
 const flexFlowSid = 'FO83947facb0df52ee4849d30275334213';
@@ -32,37 +32,39 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: "Thank you for contacting Telefon Zaufania. To chat with a counsellor, please type your name and select the Start Chat button.",
-  fields:
-    [
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-US': {
+    description:
+      'Thank you for contacting Telefon Zaufania. To chat with a counsellor, please type your name and select the Start Chat button.',
+    fields: [
       {
-        type: "InputItem",
-        label: "What is your name?",
+        type: 'InputItem',
+        label: 'What is your name?',
         attributes: {
-          name: "friendlyName",
-          type: "text",
-          placeholder: "Guest",
+          name: 'friendlyName',
+          type: 'text',
+          placeholder: 'Guest',
           required: true,
-        }
-      }
+        },
+      },
     ],
-  submitLabel: "Start Chat!"
+    submitLabel: 'Start Chat!',
+  },
 };
 
-const mapHelplineLanguage: MapHelplineLanguage = helpline => {
+const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {
   switch (helpline) {
     default:
       return defaultLanguage;
   }
-}
+};
 
 const memberDisplayOptions = {
   yourDefaultName: 'You',
   yourFriendlyNameOverride: false,
   theirFriendlyNameOverride: false,
   theirDefaultName: 'Telefon Zaufania Counsellor',
-}
+};
 
 export const config: Configuration = {
   accountSid,
@@ -72,5 +74,6 @@ export const config: Configuration = {
   preEngagementConfig,
   mapHelplineLanguage,
   memberDisplayOptions,
-  captureIp,contactType
+  captureIp,
+  contactType,
 };

--- a/configurations/ro-staging.ts
+++ b/configurations/ro-staging.ts
@@ -14,13 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import {
-  PreEngagementConfig,
-  Translations,
-  Configuration,
-  MapHelplineLanguage,
-  ContactType
-} from '../types';
+import { Translations, Configuration, MapHelplineLanguage, ContactType, LocalizedFormAttributes } from '../types';
 
 const accountSid = 'ACbeffd85714fecd060d38aa4d84c3fc03';
 const flexFlowSid = 'FO1991160f1788af24f3c207be5b16f893';
@@ -30,8 +24,7 @@ const contactType: ContactType = 'ip';
 
 const translations: Translations = {
   'en-US': {
-    MessageInputDisabledReasonHold:
-      "We'll transfer you now. Please hold for a counsellor.",
+    MessageInputDisabledReasonHold: "We'll transfer you now. Please hold for a counsellor.",
     EntryPointTagLine: 'Chat with us',
     PreEngagementDescription: "Let's get started",
     Today: 'Today',
@@ -46,19 +39,21 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: "Let's get started",
-  fields: [
-    {
-      label: 'Hidden Field',
-      type: 'InputField',
-      attributes: {
-        name: '',
-        readOnly: true,
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-US': {
+    description: "Let's get started",
+    fields: [
+      {
+        label: 'Hidden Field',
+        type: 'InputField',
+        attributes: {
+          name: '',
+          readOnly: true,
+        },
       },
-    },
-  ],
-  submitLabel: 'Start Chat!',
+    ],
+    submitLabel: 'Start Chat!',
+  },
 };
 
 const memberDisplayOptions = {
@@ -66,14 +61,14 @@ const memberDisplayOptions = {
   yourFriendlyNameOverride: false,
   theirFriendlyNameOverride: false,
   theirDefaultName: 'Telefonul Copilului Counsellor',
-}
+};
 
-const mapHelplineLanguage: MapHelplineLanguage = helpline => {
+const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {
   switch (helpline) {
     default:
       return defaultLanguage;
   }
-}
+};
 
 export const config: Configuration = {
   accountSid,
@@ -83,5 +78,6 @@ export const config: Configuration = {
   preEngagementConfig,
   mapHelplineLanguage,
   memberDisplayOptions,
-  captureIp,contactType,
+  captureIp,
+  contactType,
 };

--- a/configurations/ro-staging.ts
+++ b/configurations/ro-staging.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { Translations, Configuration, MapHelplineLanguage, ContactType, LocalizedFormAttributes } from '../types';
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
 
 const accountSid = 'ACbeffd85714fecd060d38aa4d84c3fc03';
 const flexFlowSid = 'FO1991160f1788af24f3c207be5b16f893';
@@ -39,21 +39,19 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: LocalizedFormAttributes = {
-  'en-US': {
-    description: "Let's get started",
-    fields: [
-      {
-        label: 'Hidden Field',
-        type: 'InputField',
-        attributes: {
-          name: '',
-          readOnly: true,
-        },
+const preEngagementConfig: PreEngagementConfig = {
+  description: "Let's get started",
+  fields: [
+    {
+      label: 'Hidden Field',
+      type: 'InputField',
+      attributes: {
+        name: '',
+        readOnly: true,
       },
-    ],
-    submitLabel: 'Start Chat!',
-  },
+    },
+  ],
+  submitLabel: 'Start Chat!',
 };
 
 const memberDisplayOptions = {

--- a/configurations/ro-staging.ts
+++ b/configurations/ro-staging.ts
@@ -14,7 +14,14 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
+import {
+  PreEngagementConfig,
+  Translations,
+  Configuration,
+  MapHelplineLanguage,
+  ContactType,
+  LocalizedFormAttributes,
+} from '../types';
 
 const accountSid = 'ACbeffd85714fecd060d38aa4d84c3fc03';
 const flexFlowSid = 'FO1991160f1788af24f3c207be5b16f893';
@@ -39,19 +46,21 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: "Let's get started",
-  fields: [
-    {
-      label: 'Hidden Field',
-      type: 'InputField',
-      attributes: {
-        name: '',
-        readOnly: true,
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-US': {
+    description: "Let's get started",
+    fields: [
+      {
+        label: 'Hidden Field',
+        type: 'InputField',
+        attributes: {
+          name: '',
+          readOnly: true,
+        },
       },
-    },
-  ],
-  submitLabel: 'Start Chat!',
+    ],
+    submitLabel: 'Start Chat!',
+  },
 };
 
 const memberDisplayOptions = {

--- a/configurations/uk-staging.ts
+++ b/configurations/uk-staging.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
+import { Translations, Configuration, MapHelplineLanguage, ContactType, LocalizedFormAttributes } from '../types';
 
 const accountSid = 'AC542ee9a6613ce5ff976d075a3e3bd38d';
 const flexFlowSid = 'FOfe2df2f82dd40be24d41347fff7c6f1c';
@@ -22,32 +22,34 @@ const defaultLanguage = 'en-GB';
 const captureIp = true;
 const contactType: ContactType = 'ip';
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: 'Welcome to the Revenge Porn and Report Harmful Content Helplines.',
-  fields: [
-    {
-      label: 'Select the service',
-      type: 'SelectItem',
-      attributes: {
-        name: 'helpline',
-        required: true,
-        readOnly: false,
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-GB': {
+    description: 'Welcome to the Revenge Porn and Report Harmful Content Helplines.',
+    fields: [
+      {
+        label: 'Select the service',
+        type: 'SelectItem',
+        attributes: {
+          name: 'helpline',
+          required: true,
+          readOnly: false,
+        },
+        options: [
+          {
+            value: 'RevengePorn',
+            label: 'Revenge Porn Helpline',
+            selected: true,
+          },
+          {
+            value: 'RHC',
+            label: 'Report Harmful Content Helpline',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: 'RevengePorn',
-          label: 'Revenge Porn Helpline',
-          selected: true,
-        },
-        {
-          value: 'RHC',
-          label: 'Report Harmful Content Helpline',
-          selected: false,
-        },
-      ],
-    },
-  ],
-  submitLabel: 'Start Chat!',
+    ],
+    submitLabel: 'Start Chat!',
+  },
 };
 
 const translations: Translations = {

--- a/configurations/uk-staging.ts
+++ b/configurations/uk-staging.ts
@@ -14,7 +14,14 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
+import {
+  PreEngagementConfig,
+  Translations,
+  Configuration,
+  MapHelplineLanguage,
+  ContactType,
+  LocalizedFormAttributes,
+} from '../types';
 
 const accountSid = 'AC542ee9a6613ce5ff976d075a3e3bd38d';
 const flexFlowSid = 'FOfe2df2f82dd40be24d41347fff7c6f1c';
@@ -22,32 +29,34 @@ const defaultLanguage = 'en-GB';
 const captureIp = true;
 const contactType: ContactType = 'ip';
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: 'Welcome to the Revenge Porn and Report Harmful Content Helplines.',
-  fields: [
-    {
-      label: 'Select the service',
-      type: 'SelectItem',
-      attributes: {
-        name: 'helpline',
-        required: true,
-        readOnly: false,
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-GB': {
+    description: 'Welcome to the Revenge Porn and Report Harmful Content Helplines.',
+    fields: [
+      {
+        label: 'Select the service',
+        type: 'SelectItem',
+        attributes: {
+          name: 'helpline',
+          required: true,
+          readOnly: false,
+        },
+        options: [
+          {
+            value: 'RevengePorn',
+            label: 'Revenge Porn Helpline',
+            selected: true,
+          },
+          {
+            value: 'RHC',
+            label: 'Report Harmful Content Helpline',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: 'RevengePorn',
-          label: 'Revenge Porn Helpline',
-          selected: true,
-        },
-        {
-          value: 'RHC',
-          label: 'Report Harmful Content Helpline',
-          selected: false,
-        },
-      ],
-    },
-  ],
-  submitLabel: 'Start Chat!',
+    ],
+    submitLabel: 'Start Chat!',
+  },
 };
 
 const translations: Translations = {

--- a/configurations/uk-staging.ts
+++ b/configurations/uk-staging.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { Translations, Configuration, MapHelplineLanguage, ContactType, LocalizedFormAttributes } from '../types';
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
 
 const accountSid = 'AC542ee9a6613ce5ff976d075a3e3bd38d';
 const flexFlowSid = 'FOfe2df2f82dd40be24d41347fff7c6f1c';
@@ -22,34 +22,32 @@ const defaultLanguage = 'en-GB';
 const captureIp = true;
 const contactType: ContactType = 'ip';
 
-const preEngagementConfig: LocalizedFormAttributes = {
-  'en-GB': {
-    description: 'Welcome to the Revenge Porn and Report Harmful Content Helplines.',
-    fields: [
-      {
-        label: 'Select the service',
-        type: 'SelectItem',
-        attributes: {
-          name: 'helpline',
-          required: true,
-          readOnly: false,
-        },
-        options: [
-          {
-            value: 'RevengePorn',
-            label: 'Revenge Porn Helpline',
-            selected: true,
-          },
-          {
-            value: 'RHC',
-            label: 'Report Harmful Content Helpline',
-            selected: false,
-          },
-        ],
+const preEngagementConfig: PreEngagementConfig = {
+  description: 'Welcome to the Revenge Porn and Report Harmful Content Helplines.',
+  fields: [
+    {
+      label: 'Select the service',
+      type: 'SelectItem',
+      attributes: {
+        name: 'helpline',
+        required: true,
+        readOnly: false,
       },
-    ],
-    submitLabel: 'Start Chat!',
-  },
+      options: [
+        {
+          value: 'RevengePorn',
+          label: 'Revenge Porn Helpline',
+          selected: true,
+        },
+        {
+          value: 'RHC',
+          label: 'Report Harmful Content Helpline',
+          selected: false,
+        },
+      ],
+    },
+  ],
+  submitLabel: 'Start Chat!',
 };
 
 const translations: Translations = {

--- a/configurations/za-staging.ts
+++ b/configurations/za-staging.ts
@@ -14,7 +14,14 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
+import {
+  PreEngagementConfig,
+  Translations,
+  Configuration,
+  MapHelplineLanguage,
+  ContactType,
+  LocalizedFormAttributes,
+} from '../types';
 
 const accountSid = 'AC16dd71c6fd135ee250bd213ad1efa2e8';
 const flexFlowSid = 'FOd655fd61e9e7ac6faf9d0be97a49863b';
@@ -24,76 +31,79 @@ const checkOpenHours = false;
 const contactType: ContactType = 'ip';
 const translations: Translations = {
   'en-US': {
-    WelcomeMessage: "Welcome to Childline SA’s Online Counselling Service",
-    MessageCanvasTrayContent: "",
-    MessageInputDisabledReasonHold: "Please hold for a counselor.",
-    AutoFirstMessage: "Incoming webchat contact from",
+    WelcomeMessage: 'Welcome to Childline SA’s Online Counselling Service',
+    MessageCanvasTrayContent: '',
+    MessageInputDisabledReasonHold: 'Please hold for a counselor.',
+    AutoFirstMessage: 'Incoming webchat contact from',
   },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: "Thank you for contacting Childline South Africa. To chat with a counsellor, please type your name and select the Start Chat button.",
-  fields:
-    [
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-US': {
+    description:
+      'Thank you for contacting Childline South Africa. To chat with a counsellor, please type your name and select the Start Chat button.',
+    fields: [
       {
-        type: "InputItem",
-        label: "What is your name? (This may be just a screen name, or a nick name, if you are not comfortable giving us your real name) \n We are here Monday – Friday, 11am-1pm & 2pm-6pm. If you need to speak to a Counsellor urgently, call our 24 hour Tollfree Number on 116.",
+        type: 'InputItem',
+        label:
+          'What is your name? (This may be just a screen name, or a nick name, if you are not comfortable giving us your real name) \n We are here Monday – Friday, 11am-1pm & 2pm-6pm. If you need to speak to a Counsellor urgently, call our 24 hour Tollfree Number on 116.',
         attributes: {
-          name: "friendlyName",
-          type: "text",
+          name: 'friendlyName',
+          type: 'text',
           placeholder: "Guest's name. Please enter only your name.",
           required: true,
-        }
-      }
+        },
+      },
     ],
-  submitLabel: "Start Chat!"
+    submitLabel: 'Start Chat!',
+  },
 };
 
 const closedHours: PreEngagementConfig = {
-  description: "Our counsellors are currently offline. We are here Monday – Friday, 11am-1pm & 2pm-6pm. If you need to speak to a Counsellor, call our 24 hour Tollfree Number on 116. If you feel you are in immediate danger, please call the Police on 10111.",
-  fields:
-    [
-      {
-        label: 'Hidden Field',
-        type: 'InputField',
-        attributes: {
-          name: '',
-          required: true,
-          readOnly: true,
-        },
-      },
-    ],
+  description:
+    'Our counsellors are currently offline. We are here Monday – Friday, 11am-1pm & 2pm-6pm. If you need to speak to a Counsellor, call our 24 hour Tollfree Number on 116. If you feel you are in immediate danger, please call the Police on 10111.',
+  fields: [
+    {
+      label: 'Hidden Field',
+      type: 'InputField',
+      attributes: {
+        name: '',
+        required: true,
+        readOnly: true,
+      },
+    },
+  ],
 };
 
 const holidayHours: PreEngagementConfig = {
-  description: "Our counsellors are currently offline for the Public Holiday today. We are here on normal working days: Monday – Friday, 11am-1pm & 2pm-6pm. Please note that messages sent on this platform out of these hours are not received by our team and if you need to speak to a Counsellor, call our 24 hour Tollfree Number on 116. If you feel you are in immediate danger, please call the Police on 10111.",
-  fields:
-    [
-      {
-        label: 'Hidden Field',
-        type: 'InputField',
-        attributes: {
-          name: '',
-          required: true,
-          readOnly: true,
-        },
-      },
-    ],
+  description:
+    'Our counsellors are currently offline for the Public Holiday today. We are here on normal working days: Monday – Friday, 11am-1pm & 2pm-6pm. Please note that messages sent on this platform out of these hours are not received by our team and if you need to speak to a Counsellor, call our 24 hour Tollfree Number on 116. If you feel you are in immediate danger, please call the Police on 10111.',
+  fields: [
+    {
+      label: 'Hidden Field',
+      type: 'InputField',
+      attributes: {
+        name: '',
+        required: true,
+        readOnly: true,
+      },
+    },
+  ],
 };
 
-const mapHelplineLanguage: MapHelplineLanguage = helpline => {
+const mapHelplineLanguage: MapHelplineLanguage = (helpline: string) => {
   switch (helpline) {
     default:
       return defaultLanguage;
   }
-}
+};
 
 const memberDisplayOptions = {
   yourDefaultName: 'You',
   yourFriendlyNameOverride: false,
   theirFriendlyNameOverride: false,
   theirDefaultName: 'Counsellor',
-}
+};
 
 export const config: Configuration = {
   accountSid,

--- a/configurations/za-staging.ts
+++ b/configurations/za-staging.ts
@@ -14,7 +14,14 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
+import {
+  PreEngagementConfig,
+  Translations,
+  Configuration,
+  MapHelplineLanguage,
+  ContactType,
+  LocalizedFormAttributes,
+} from '../types';
 
 const accountSid = 'AC16dd71c6fd135ee250bd213ad1efa2e8';
 const flexFlowSid = 'FOd655fd61e9e7ac6faf9d0be97a49863b';
@@ -31,23 +38,25 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description:
-    'Thank you for contacting Childline South Africa. To chat with a counsellor, please type your name and select the Start Chat button.',
-  fields: [
-    {
-      type: 'InputItem',
-      label:
-        'What is your name? (This may be just a screen name, or a nick name, if you are not comfortable giving us your real name) \n We are here Monday – Friday, 11am-1pm & 2pm-6pm. If you need to speak to a Counsellor urgently, call our 24 hour Tollfree Number on 116.',
-      attributes: {
-        name: 'friendlyName',
-        type: 'text',
-        placeholder: "Guest's name. Please enter only your name.",
-        required: true,
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-US': {
+    description:
+      'Thank you for contacting Childline South Africa. To chat with a counsellor, please type your name and select the Start Chat button.',
+    fields: [
+      {
+        type: 'InputItem',
+        label:
+          'What is your name? (This may be just a screen name, or a nick name, if you are not comfortable giving us your real name) \n We are here Monday – Friday, 11am-1pm & 2pm-6pm. If you need to speak to a Counsellor urgently, call our 24 hour Tollfree Number on 116.',
+        attributes: {
+          name: 'friendlyName',
+          type: 'text',
+          placeholder: "Guest's name. Please enter only your name.",
+          required: true,
+        },
       },
-    },
-  ],
-  submitLabel: 'Start Chat!',
+    ],
+    submitLabel: 'Start Chat!',
+  },
 };
 
 const closedHours: PreEngagementConfig = {

--- a/configurations/za-staging.ts
+++ b/configurations/za-staging.ts
@@ -14,14 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import {
-  PreEngagementConfig,
-  Translations,
-  Configuration,
-  MapHelplineLanguage,
-  ContactType,
-  LocalizedFormAttributes,
-} from '../types';
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
 
 const accountSid = 'AC16dd71c6fd135ee250bd213ad1efa2e8';
 const flexFlowSid = 'FOd655fd61e9e7ac6faf9d0be97a49863b';
@@ -38,25 +31,23 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: LocalizedFormAttributes = {
-  'en-US': {
-    description:
-      'Thank you for contacting Childline South Africa. To chat with a counsellor, please type your name and select the Start Chat button.',
-    fields: [
-      {
-        type: 'InputItem',
-        label:
-          'What is your name? (This may be just a screen name, or a nick name, if you are not comfortable giving us your real name) \n We are here Monday – Friday, 11am-1pm & 2pm-6pm. If you need to speak to a Counsellor urgently, call our 24 hour Tollfree Number on 116.',
-        attributes: {
-          name: 'friendlyName',
-          type: 'text',
-          placeholder: "Guest's name. Please enter only your name.",
-          required: true,
-        },
+const preEngagementConfig: PreEngagementConfig = {
+  description:
+    'Thank you for contacting Childline South Africa. To chat with a counsellor, please type your name and select the Start Chat button.',
+  fields: [
+    {
+      type: 'InputItem',
+      label:
+        'What is your name? (This may be just a screen name, or a nick name, if you are not comfortable giving us your real name) \n We are here Monday – Friday, 11am-1pm & 2pm-6pm. If you need to speak to a Counsellor urgently, call our 24 hour Tollfree Number on 116.',
+      attributes: {
+        name: 'friendlyName',
+        type: 'text',
+        placeholder: "Guest's name. Please enter only your name.",
+        required: true,
       },
-    ],
-    submitLabel: 'Start Chat!',
-  },
+    },
+  ],
+  submitLabel: 'Start Chat!',
 };
 
 const closedHours: PreEngagementConfig = {
@@ -91,7 +82,7 @@ const holidayHours: PreEngagementConfig = {
   ],
 };
 
-const mapHelplineLanguage: MapHelplineLanguage = (helpline: string) => {
+const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {
   switch (helpline) {
     default:
       return defaultLanguage;

--- a/configurations/zm-staging.ts
+++ b/configurations/zm-staging.ts
@@ -14,7 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { Translations, Configuration, MapHelplineLanguage, LocalizedFormAttributes } from '../types';
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage } from '../types';
 
 const accountSid = 'ACc59300c7ca018e8652e4d6d86c2d50e6';
 const flexFlowSid = 'FObb9dfe97f1c59f455ab01811bec74cd5';
@@ -123,59 +123,57 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: LocalizedFormAttributes = {
-  'en-US': {
-    description: "Let's get started",
-    fields: [
-      {
-        label: 'Select your language',
-        type: 'SelectItem',
-        attributes: {
-          name: 'language',
-          required: true,
-          readOnly: false,
-        },
-        options: [
-          {
-            value: 'English',
-            label: '1. English',
-            selected: true,
-          },
-          {
-            value: 'Bemba',
-            label: '2. Bemba',
-            selected: false,
-          },
-          {
-            value: 'Tonga',
-            label: '3. Tonga',
-            selected: false,
-          },
-          {
-            value: 'Lunda',
-            label: '4. Lunda',
-            selected: false,
-          },
-          {
-            value: 'Nyanja',
-            label: '5. Nyanja',
-            selected: false,
-          },
-          {
-            value: 'Kaonde',
-            label: '6. Kaonde',
-            selected: false,
-          },
-          {
-            value: 'Lozi',
-            label: '7. Lozi',
-            selected: false,
-          },
-        ],
+const preEngagementConfig: PreEngagementConfig = {
+  description: "Let's get started",
+  fields: [
+    {
+      label: 'Select your language',
+      type: 'SelectItem',
+      attributes: {
+        name: 'language',
+        required: true,
+        readOnly: false,
       },
-    ],
-    submitLabel: 'Start Chat!',
-  },
+      options: [
+        {
+          value: 'English',
+          label: '1. English',
+          selected: true,
+        },
+        {
+          value: 'Bemba',
+          label: '2. Bemba',
+          selected: false,
+        },
+        {
+          value: 'Tonga',
+          label: '3. Tonga',
+          selected: false,
+        },
+        {
+          value: 'Lunda',
+          label: '4. Lunda',
+          selected: false,
+        },
+        {
+          value: 'Nyanja',
+          label: '5. Nyanja',
+          selected: false,
+        },
+        {
+          value: 'Kaonde',
+          label: '6. Kaonde',
+          selected: false,
+        },
+        {
+          value: 'Lozi',
+          label: '7. Lozi',
+          selected: false,
+        },
+      ],
+    },
+  ],
+  submitLabel: 'Start Chat!',
 };
 
 const memberDisplayOptions = {

--- a/configurations/zm-staging.ts
+++ b/configurations/zm-staging.ts
@@ -14,7 +14,13 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage } from '../types';
+import {
+  PreEngagementConfig,
+  Translations,
+  Configuration,
+  MapHelplineLanguage,
+  LocalizedFormAttributes,
+} from '../types';
 
 const accountSid = 'ACc59300c7ca018e8652e4d6d86c2d50e6';
 const flexFlowSid = 'FObb9dfe97f1c59f455ab01811bec74cd5';
@@ -123,57 +129,59 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: "Let's get started",
-  fields: [
-    {
-      label: 'Select your language',
-      type: 'SelectItem',
-      attributes: {
-        name: 'language',
-        required: true,
-        readOnly: false,
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-US': {
+    description: "Let's get started",
+    fields: [
+      {
+        label: 'Select your language',
+        type: 'SelectItem',
+        attributes: {
+          name: 'language',
+          required: true,
+          readOnly: false,
+        },
+        options: [
+          {
+            value: 'English',
+            label: '1. English',
+            selected: true,
+          },
+          {
+            value: 'Bemba',
+            label: '2. Bemba',
+            selected: false,
+          },
+          {
+            value: 'Tonga',
+            label: '3. Tonga',
+            selected: false,
+          },
+          {
+            value: 'Lunda',
+            label: '4. Lunda',
+            selected: false,
+          },
+          {
+            value: 'Nyanja',
+            label: '5. Nyanja',
+            selected: false,
+          },
+          {
+            value: 'Kaonde',
+            label: '6. Kaonde',
+            selected: false,
+          },
+          {
+            value: 'Lozi',
+            label: '7. Lozi',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: 'English',
-          label: '1. English',
-          selected: true,
-        },
-        {
-          value: 'Bemba',
-          label: '2. Bemba',
-          selected: false,
-        },
-        {
-          value: 'Tonga',
-          label: '3. Tonga',
-          selected: false,
-        },
-        {
-          value: 'Lunda',
-          label: '4. Lunda',
-          selected: false,
-        },
-        {
-          value: 'Nyanja',
-          label: '5. Nyanja',
-          selected: false,
-        },
-        {
-          value: 'Kaonde',
-          label: '6. Kaonde',
-          selected: false,
-        },
-        {
-          value: 'Lozi',
-          label: '7. Lozi',
-          selected: false,
-        },
-      ],
-    },
-  ],
-  submitLabel: 'Start Chat!',
+    ],
+    submitLabel: 'Start Chat!',
+  },
 };
 
 const memberDisplayOptions = {

--- a/configurations/zm-staging.ts
+++ b/configurations/zm-staging.ts
@@ -14,13 +14,13 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage } from '../types';
+import { Translations, Configuration, MapHelplineLanguage, LocalizedFormAttributes } from '../types';
 
 const accountSid = 'ACc59300c7ca018e8652e4d6d86c2d50e6';
 const flexFlowSid = 'FObb9dfe97f1c59f455ab01811bec74cd5';
 const defaultLanguage = 'en-US';
 const captureIp = true;
-const contactType = 'ip'
+const contactType = 'ip';
 
 const translations: Translations = {
   'en-US': {
@@ -123,57 +123,59 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description: "Let's get started",
-  fields: [
-    {
-      label: 'Select your language',
-      type: 'SelectItem',
-      attributes: {
-        name: 'language',
-        required: true,
-        readOnly: false,
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-US': {
+    description: "Let's get started",
+    fields: [
+      {
+        label: 'Select your language',
+        type: 'SelectItem',
+        attributes: {
+          name: 'language',
+          required: true,
+          readOnly: false,
+        },
+        options: [
+          {
+            value: 'English',
+            label: '1. English',
+            selected: true,
+          },
+          {
+            value: 'Bemba',
+            label: '2. Bemba',
+            selected: false,
+          },
+          {
+            value: 'Tonga',
+            label: '3. Tonga',
+            selected: false,
+          },
+          {
+            value: 'Lunda',
+            label: '4. Lunda',
+            selected: false,
+          },
+          {
+            value: 'Nyanja',
+            label: '5. Nyanja',
+            selected: false,
+          },
+          {
+            value: 'Kaonde',
+            label: '6. Kaonde',
+            selected: false,
+          },
+          {
+            value: 'Lozi',
+            label: '7. Lozi',
+            selected: false,
+          },
+        ],
       },
-      options: [
-        {
-          value: 'English',
-          label: '1. English',
-          selected: true,
-        },
-        {
-          value: 'Bemba',
-          label: '2. Bemba',
-          selected: false,
-        },
-        {
-          value: 'Tonga',
-          label: '3. Tonga',
-          selected: false,
-        },
-        {
-          value: 'Lunda',
-          label: '4. Lunda',
-          selected: false,
-        },
-        {
-          value: 'Nyanja',
-          label: '5. Nyanja',
-          selected: false,
-        },
-        {
-          value: 'Kaonde',
-          label: '6. Kaonde',
-          selected: false,
-        },
-        {
-          value: 'Lozi',
-          label: '7. Lozi',
-          selected: false,
-        },
-      ],
-    },
-  ],
-  submitLabel: 'Start Chat!',
+    ],
+    submitLabel: 'Start Chat!',
+  },
 };
 
 const memberDisplayOptions = {
@@ -199,5 +201,5 @@ export const config: Configuration = {
   mapHelplineLanguage,
   memberDisplayOptions,
   captureIp,
-  contactType
+  contactType,
 };

--- a/configurations/zw-staging.ts
+++ b/configurations/zw-staging.ts
@@ -14,7 +14,14 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
+import {
+  PreEngagementConfig,
+  Translations,
+  Configuration,
+  MapHelplineLanguage,
+  ContactType,
+  LocalizedFormAttributes,
+} from '../types';
 
 const accountSid = 'AC48d146ce2460184b8944cc7fdf8c5d25';
 const flexFlowSid = 'FO7494aba81cf5899543d90aa1902a1064';
@@ -32,22 +39,24 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description:
-    'Thank you for contacting Childline Zimbabwe. To chat with a counsellor, please type your name and select the Start Chat button.',
-  fields: [
-    {
-      type: 'InputItem',
-      label: 'What is your name?',
-      attributes: {
-        name: 'friendlyName',
-        type: 'text',
-        placeholder: 'Guest',
-        required: true,
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-US': {
+    description:
+      'Thank you for contacting Childline Zimbabwe. To chat with a counsellor, please type your name and select the Start Chat button.',
+    fields: [
+      {
+        type: 'InputItem',
+        label: 'What is your name?',
+        attributes: {
+          name: 'friendlyName',
+          type: 'text',
+          placeholder: 'Guest',
+          required: true,
+        },
       },
-    },
-  ],
-  submitLabel: 'Start Chat!',
+    ],
+    submitLabel: 'Start Chat!',
+  },
 };
 
 const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {

--- a/configurations/zw-staging.ts
+++ b/configurations/zw-staging.ts
@@ -14,7 +14,14 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
+import {
+  PreEngagementConfig,
+  Translations,
+  Configuration,
+  MapHelplineLanguage,
+  ContactType,
+  LocalizedFormAttributes,
+} from '../types';
 
 const accountSid = 'AC48d146ce2460184b8944cc7fdf8c5d25';
 const flexFlowSid = 'FO7494aba81cf5899543d90aa1902a1064';
@@ -32,22 +39,24 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: PreEngagementConfig = {
-  description:
-    'Thank you for contacting Childline Zimbabwe. To chat with a counsellor, please type your name and select the Start Chat button.',
-  fields: [
-    {
-      type: 'InputItem',
-      label: 'What is your name?',
-      attributes: {
-        name: 'friendlyName',
-        type: 'text',
-        placeholder: 'Guest',
-        required: true,
+const preEngagementConfig: LocalizedFormAttributes = {
+  'en-US': {
+    description:
+      'Thank you for contacting Childline Zimbabwe. To chat with a counsellor, please type your name and select the Start Chat button.',
+    fields: [
+      {
+        type: 'InputItem',
+        label: 'What is your name?',
+        attributes: {
+          name: 'friendlyName',
+          type: 'text',
+          placeholder: 'Guest',
+          required: true,
+        },
       },
-    },
-  ],
-  submitLabel: 'Start Chat!',
+    ],
+    submitLabel: 'Start Chat!',
+  },
 };
 
 const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {
@@ -65,6 +74,7 @@ const memberDisplayOptions = {
   theirDefaultName: 'Childline Zimbabwe Counsellor',
 };
 
+// eslint-disable-next-line import/no-unused-modules
 export const config: Configuration = {
   accountSid,
   flexFlowSid,
@@ -74,5 +84,5 @@ export const config: Configuration = {
   mapHelplineLanguage,
   memberDisplayOptions,
   captureIp,
-  contactType
+  contactType,
 };

--- a/configurations/zw-staging.ts
+++ b/configurations/zw-staging.ts
@@ -14,14 +14,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import {
-  PreEngagementConfig,
-  Translations,
-  Configuration,
-  MapHelplineLanguage,
-  ContactType,
-  LocalizedFormAttributes,
-} from '../types';
+import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage, ContactType } from '../types';
 
 const accountSid = 'AC48d146ce2460184b8944cc7fdf8c5d25';
 const flexFlowSid = 'FO7494aba81cf5899543d90aa1902a1064';
@@ -39,24 +32,22 @@ const translations: Translations = {
   },
 };
 
-const preEngagementConfig: LocalizedFormAttributes = {
-  'en-US': {
-    description:
-      'Thank you for contacting Childline Zimbabwe. To chat with a counsellor, please type your name and select the Start Chat button.',
-    fields: [
-      {
-        type: 'InputItem',
-        label: 'What is your name?',
-        attributes: {
-          name: 'friendlyName',
-          type: 'text',
-          placeholder: 'Guest',
-          required: true,
-        },
+const preEngagementConfig: PreEngagementConfig = {
+  description:
+    'Thank you for contacting Childline Zimbabwe. To chat with a counsellor, please type your name and select the Start Chat button.',
+  fields: [
+    {
+      type: 'InputItem',
+      label: 'What is your name?',
+      attributes: {
+        name: 'friendlyName',
+        type: 'text',
+        placeholder: 'Guest',
+        required: true,
       },
-    ],
-    submitLabel: 'Start Chat!',
-  },
+    },
+  ],
+  submitLabel: 'Start Chat!',
 };
 
 const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {
@@ -74,7 +65,6 @@ const memberDisplayOptions = {
   theirDefaultName: 'Childline Zimbabwe Counsellor',
 };
 
-// eslint-disable-next-line import/no-unused-modules
 export const config: Configuration = {
   accountSid,
   flexFlowSid,

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -31,7 +31,7 @@ import { applyMobileOptimization } from './mobile-optimization';
 import { aseloReducer } from './aselo-webchat-state';
 import { subscribeToChannel } from './task';
 import { addContactIdentifierToContext } from './contact-identifier';
-import type { Configuration, LocalizedFormAttributes } from '../types';
+import { Configuration, FormField, LocalizedFormAttributes, PreEngagementConfig } from '../types';
 // eslint-disable-next-line import/no-unresolved
 import { config } from './config';
 import { renderEmojis } from './emoji-picker/renderEmojis';
@@ -98,6 +98,7 @@ const setChannelAfterStartEngagement = async (channel: Channel, manager: FlexWeb
   const message = `${translations[initialLanguage].AutoFirstMessage} ${contactIdentifier}`;
   channel.sendMessage(message);
 };
+// eslint-disable-next-line sonarjs/cognitive-complexity
 export const initWebchat = async () => {
   let ip: string | undefined;
   if (currentConfig.captureIp) {
@@ -113,7 +114,7 @@ export const initWebchat = async () => {
     accountSid: currentConfig.accountSid,
     flexFlowSid: currentConfig.flexFlowSid,
     startEngagementOnInit: false,
-    preEngagementConfig: currentConfig.preEngagementConfig,
+    preEngagementConfig: currentConfig.preEngagementConfig.language as PreEngagementConfig,
     context: {
       ip,
     },
@@ -142,9 +143,6 @@ export const initWebchat = async () => {
   const changeLanguageWebChat = getChangeLanguageWebChat(manager, currentConfig);
 
   changeLanguageWebChat(externalWebChatLanguage || initialLanguage);
-  currentConfig.preEngagementConfig.description = (manager.strings as Record<string, string>)[
-    currentConfig.preEngagementConfig.description
-  ];
 
   // If caller is waiting for a counselor to connect, disable input (default language)
   if (manager.chatClient) {

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -141,7 +141,10 @@ export const initWebchat = async () => {
 
   const changeLanguageWebChat = getChangeLanguageWebChat(manager, currentConfig);
 
-  changeLanguageWebChat(externalWebChatLanguage || initialLanguage, preEngagementConfig as LocalizedFormAttributes);
+  changeLanguageWebChat(externalWebChatLanguage || initialLanguage);
+  currentConfig.preEngagementConfig.description = (manager.strings as Record<string, string>)[
+    currentConfig.preEngagementConfig.description
+  ];
 
   // If caller is waiting for a counselor to connect, disable input (default language)
   if (manager.chatClient) {
@@ -177,7 +180,7 @@ export const initWebchat = async () => {
     const { language } = payload.formData;
 
     // Here we collect caller language (from preEngagement select) and change UI language
-    changeLanguageWebChat(language || externalWebChatLanguage, preEngagementConfig as LocalizedFormAttributes);
+    changeLanguageWebChat(language || externalWebChatLanguage);
 
     const channel = await chatChannel(manager);
 

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -31,7 +31,7 @@ import { applyMobileOptimization } from './mobile-optimization';
 import { aseloReducer } from './aselo-webchat-state';
 import { subscribeToChannel } from './task';
 import { addContactIdentifierToContext } from './contact-identifier';
-import type { Configuration } from '../types';
+import type { Configuration, LocalizedFormAttributes } from '../types';
 // eslint-disable-next-line import/no-unresolved
 import { config } from './config';
 import { renderEmojis } from './emoji-picker/renderEmojis';
@@ -50,7 +50,7 @@ export const getCurrentConfig = (): Configuration => {
 const currentConfig = getCurrentConfig();
 const externalWebChatLanguage = getWebChatLanguageAttributeValue();
 
-const { defaultLanguage, translations } = currentConfig;
+const { defaultLanguage, translations, preEngagementConfig } = currentConfig;
 const initialLanguage = defaultLanguage;
 
 const chatChannel = async (manager: FlexWebChat.Manager): Promise<Channel> => {
@@ -141,7 +141,7 @@ export const initWebchat = async () => {
 
   const changeLanguageWebChat = getChangeLanguageWebChat(manager, currentConfig);
 
-  changeLanguageWebChat(externalWebChatLanguage || initialLanguage);
+  changeLanguageWebChat(externalWebChatLanguage || initialLanguage, preEngagementConfig as LocalizedFormAttributes);
 
   // If caller is waiting for a counselor to connect, disable input (default language)
   if (manager.chatClient) {
@@ -177,7 +177,7 @@ export const initWebchat = async () => {
     const { language } = payload.formData;
 
     // Here we collect caller language (from preEngagement select) and change UI language
-    changeLanguageWebChat(language || externalWebChatLanguage);
+    changeLanguageWebChat(language || externalWebChatLanguage, preEngagementConfig as LocalizedFormAttributes);
 
     const channel = await chatChannel(manager);
 

--- a/src/language.ts
+++ b/src/language.ts
@@ -67,7 +67,7 @@ export const getChangeLanguageWebChat = (manager: FlexWebChat.Manager, config: C
 
   return (language: string) => {
     try {
-      const preEngagement = getPreEngagementForm(language, preEngagementConfig);
+      const preEngagement = getPreEngagementForm(language || defaultLanguage, preEngagementConfig);
       manager.updateConfig({
         preEngagementConfig: preEngagement,
       });

--- a/src/language.ts
+++ b/src/language.ts
@@ -16,7 +16,7 @@
 
 import * as FlexWebChat from '@twilio/flex-webchat-ui';
 
-import { Configuration } from '../types';
+import { Configuration, LocalizedFormAttributes, PreEngagementConfig, Translations } from '../types';
 import standardTranslations from './translations';
 
 /**
@@ -33,6 +33,11 @@ const standardTranslationsForLanguage = (language: string): Record<string, strin
   const languageTranslations = standardTranslations[languageOnlyCode] ?? {};
   const cultureSpecificTranslations = (languageOnlyCode !== language ? standardTranslations[language] : {}) ?? {};
   return { ...languageTranslations, ...cultureSpecificTranslations };
+};
+
+const getPreEngagementForm = (language: string, preEngagementForm: LocalizedFormAttributes) => {
+  const [languageOnlyCode] = language.split('-');
+  return preEngagementForm[language] ? preEngagementForm[language] : preEngagementForm[languageOnlyCode] ?? {};
 };
 
 export const getChangeLanguageWebChat = (manager: FlexWebChat.Manager, config: Configuration) => {
@@ -60,8 +65,10 @@ export const getChangeLanguageWebChat = (manager: FlexWebChat.Manager, config: C
     }
   };
 
-  return (language: string) => {
+  return (language: string, preEngagementForm: LocalizedFormAttributes) => {
     try {
+      const preEngagementConfig = getPreEngagementForm(language, preEngagementForm);
+      manager.updateConfig({ preEngagementConfig });
       setNewLanguage(language);
     } catch (err) {
       const translationErrorMsg = 'Could not translate, using default';

--- a/src/language.ts
+++ b/src/language.ts
@@ -65,10 +65,12 @@ export const getChangeLanguageWebChat = (manager: FlexWebChat.Manager, config: C
     }
   };
 
-  return (language: string, preEngagementForm: LocalizedFormAttributes) => {
+  return (language: string) => {
     try {
-      const preEngagementConfig = getPreEngagementForm(language, preEngagementForm);
-      manager.updateConfig({ preEngagementConfig });
+      /*
+       * const preEngagementConfig = getPreEngagementForm(language, preEngagementForm);
+       * manager.updateConfig({ preEngagementConfig });
+       */
       setNewLanguage(language);
     } catch (err) {
       const translationErrorMsg = 'Could not translate, using default';

--- a/src/language.ts
+++ b/src/language.ts
@@ -41,7 +41,7 @@ const getPreEngagementForm = (language: string, preEngagementForm: LocalizedForm
 };
 
 export const getChangeLanguageWebChat = (manager: FlexWebChat.Manager, config: Configuration) => {
-  const { defaultLanguage, translations: configTranslations } = config;
+  const { defaultLanguage, translations: configTranslations, preEngagementConfig } = config;
   const setNewLanguage = (language: string) => {
     const twilioStrings = { ...manager.strings }; // save the originals
     const defaultLanguageTranslations = standardTranslationsForLanguage(defaultLanguage);
@@ -67,10 +67,11 @@ export const getChangeLanguageWebChat = (manager: FlexWebChat.Manager, config: C
 
   return (language: string) => {
     try {
-      /*
-       * const preEngagementConfig = getPreEngagementForm(language, preEngagementForm);
-       * manager.updateConfig({ preEngagementConfig });
-       */
+      const preEngagement = getPreEngagementForm(language, preEngagementConfig);
+      manager.updateConfig({
+        preEngagementConfig: preEngagement,
+      });
+
       setNewLanguage(language);
     } catch (err) {
       const translationErrorMsg = 'Could not translate, using default';

--- a/types.ts
+++ b/types.ts
@@ -25,6 +25,10 @@ export type Translations = {
   };
 };
 
+export type LocalizedFormAttributes = {
+  [language: string]: PreEngagementConfig;
+} & PreEngagementConfig;
+
 export type MapHelplineLanguage = (helpline: string) => string;
 
 export type Configuration = {

--- a/types.ts
+++ b/types.ts
@@ -17,7 +17,6 @@
 import { FormAttributes as PreEngagementConfig } from '@twilio/flex-ui-core';
 import type { MemberDisplayOptions } from '@twilio/flex-ui-core/src/components/channel/MessagingCanvas';
 
-// eslint-disable-next-line import/no-unused-modules
 export type { PreEngagementConfig };
 
 export type Translations = {
@@ -26,54 +25,31 @@ export type Translations = {
   };
 };
 
-type FormField = {
-  label: string;
-  type: string;
-  attributes: { name: string; required: true; readOnly: false };
-  options: ({ value: string; label: string; selected: true } | { value: string; label: string; selected: false })[];
+export type FormField = {
+  label?: string;
+  type?: string;
+  attributes?: { name?: string; type?: string; required?: boolean; readOnly?: boolean; placeholder?: string };
+  options?: (
+    | { value?: string; label?: string; selected?: true }
+    | { value?: string; label?: string; selected?: false }
+  )[];
 };
 
-// eslint-disable-next-line import/no-unused-modules
-export interface FormAttribute {
-  [locale: string]: {
+export type LocalizedFormAttributes = {
+  [language: string]: {
     description: string;
     fields: {
       label: string;
       type: string;
-      attributes: {
-        name: string;
-        required?: boolean;
-        readOnly?: boolean;
-      };
-      options?: {
-        value: string;
-        label: string;
-        selected?: boolean;
-      }[];
+      attributes: { name: string; type?: string; required?: boolean; readOnly?: boolean; placeholder?: string };
+      options?: (
+        | { value: string; label: string; selected: true }
+        | { value: string; label: string; selected: false }
+      )[];
     }[];
     submitLabel: string;
   };
-}
-
-// eslint-disable-next-line import/no-unused-modules
-export interface LocalizedFormAttribute {
-  [language: string]: {
-    type?: string;
-    name?: string;
-    hideMessage?: boolean;
-    fields: Array<FormField>;
-    submitLabel?: string;
-    description?: string;
-    message?: string;
-    disabled?: boolean;
-    readOnly?: boolean;
-  } & PreEngagementConfig;
-}
-
-// eslint-disable-next-line import/no-unused-modules
-export type LocalizedFormAttributes = {
-  [language: string]: PreEngagementConfig;
-} & PreEngagementConfig;
+};
 
 export type MapHelplineLanguage = (helpline: string) => string;
 
@@ -82,7 +58,7 @@ export type Configuration = {
   flexFlowSid: string;
   defaultLanguage: string;
   translations: Translations;
-  preEngagementConfig: PreEngagementConfig;
+  preEngagementConfig: LocalizedFormAttributes;
   closedHours?: PreEngagementConfig;
   holidayHours?: PreEngagementConfig;
   mapHelplineLanguage: MapHelplineLanguage;

--- a/types.ts
+++ b/types.ts
@@ -17,6 +17,7 @@
 import { FormAttributes as PreEngagementConfig } from '@twilio/flex-ui-core';
 import type { MemberDisplayOptions } from '@twilio/flex-ui-core/src/components/channel/MessagingCanvas';
 
+// eslint-disable-next-line import/no-unused-modules
 export type { PreEngagementConfig };
 
 export type Translations = {
@@ -25,6 +26,51 @@ export type Translations = {
   };
 };
 
+type FormField = {
+  label: string;
+  type: string;
+  attributes: { name: string; required: true; readOnly: false };
+  options: ({ value: string; label: string; selected: true } | { value: string; label: string; selected: false })[];
+};
+
+// eslint-disable-next-line import/no-unused-modules
+export interface FormAttribute {
+  [locale: string]: {
+    description: string;
+    fields: {
+      label: string;
+      type: string;
+      attributes: {
+        name: string;
+        required?: boolean;
+        readOnly?: boolean;
+      };
+      options?: {
+        value: string;
+        label: string;
+        selected?: boolean;
+      }[];
+    }[];
+    submitLabel: string;
+  };
+}
+
+// eslint-disable-next-line import/no-unused-modules
+export interface LocalizedFormAttribute {
+  [language: string]: {
+    type?: string;
+    name?: string;
+    hideMessage?: boolean;
+    fields: Array<FormField>;
+    submitLabel?: string;
+    description?: string;
+    message?: string;
+    disabled?: boolean;
+    readOnly?: boolean;
+  } & PreEngagementConfig;
+}
+
+// eslint-disable-next-line import/no-unused-modules
 export type LocalizedFormAttributes = {
   [language: string]: PreEngagementConfig;
 } & PreEngagementConfig;


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- Changes: translate the pre-engagement form based on the default language or language option passed into the data-language attribute.

### Checklist
- [x] Corresponding issue has been opened
- [N/A] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes CHI-1718

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
