### PR TITLE
Fix Blank Form State

### DIFF
--- a/src/pre-engagement-form/state.ts
+++ b/src/pre-engagement-form/state.ts
@@ -28,7 +28,7 @@ const initialState: PreEngagementFormState = {
   formDefinition: undefined,
 };
 
-const RESET_FORM = 'RESET_FORM';
+const RESET_FORM_STATE = 'RESET_FORM_STATE';
 const SET_VALUE = 'SET_VALUE';
 const SET_FORM_DEFINITION = 'SET_FORM_DEFINITION';
 
@@ -41,7 +41,7 @@ type SetValue = {
 };
 
 type ResetForm = {
-  type: typeof RESET_FORM;
+  type: typeof RESET_FORM_STATE;
 };
 
 type SetFormDefinition = {
@@ -52,7 +52,7 @@ type SetFormDefinition = {
 type Action = SetValue | ResetForm | SetFormDefinition;
 
 export const resetForm = (): ResetForm => ({
-  type: RESET_FORM,
+  type: RESET_FORM_STATE,
 });
 
 export const setValue = (name: string, value: string): SetValue => ({
@@ -79,8 +79,11 @@ export const preEngagementFormReducer = (state = initialState, action: Action) =
     };
   }
 
-  if (action.type === RESET_FORM) {
-    return initialState;
+  if (action.type === RESET_FORM_STATE) {
+    return {
+      ...state,
+      formState: initialState.formState,
+    };
   }
 
   if (action.type === SET_FORM_DEFINITION) {


### PR DESCRIPTION
## Description
Simple fix to the blank screen after hitting End Chat.

### Related Issues
Fixes https://tech-matters.atlassian.net/browse/CHI-1866

### Verification steps
Hit End Chat and check that it goes back to the pre-engagement form instead of the blank screen.
