### PR TITLE
`Quick Exit` position fix

### DIFF
--- a/src/end-chat/CloseChatButtons.tsx
+++ b/src/end-chat/CloseChatButtons.tsx
@@ -21,14 +21,14 @@ import { connect } from 'react-redux';
 import Exit from './QuickExit';
 import End from './EndChat';
 import { AseloWebchatState } from '../aselo-webchat-state';
-import { ButtonWrapper } from './end-chat-styles';
+import { ButtonsWrapper } from './end-chat-styles';
 
 const CloseChatButtons = ({ channelSid, token, language, taskSid }: MapStateToProps) => {
   if (!channelSid || !token) {
     return null;
   }
   return (
-    <ButtonWrapper>
+    <ButtonsWrapper>
       <End
         channelSid={channelSid}
         token={token}
@@ -36,7 +36,7 @@ const CloseChatButtons = ({ channelSid, token, language, taskSid }: MapStateToPr
         action={taskSid ? 'finishTask' : 'restartEngagement'}
       />
       <Exit channelSid={channelSid} token={token} language={language} finishTask={Boolean(taskSid)} />
-    </ButtonWrapper>
+    </ButtonsWrapper>
   );
 };
 

--- a/src/end-chat/EndChat.tsx
+++ b/src/end-chat/EndChat.tsx
@@ -20,7 +20,7 @@ import { Template, Icon } from '@twilio/flex-webchat-ui';
 import * as FlexWebChat from '@twilio/flex-webchat-ui';
 
 import { finishChatTask } from './end-chat-service';
-import { EndChatWrapper, IconWrapper, StyledEndButton } from './end-chat-styles';
+import { EndChatText, EndChatIcon, StyledEndButton } from './end-chat-styles';
 
 type Props = {
   channelSid: string;
@@ -52,12 +52,12 @@ export default function EndChat({ channelSid, token, language, action }: Props) 
   };
   return (
     <StyledEndButton onClick={handleEndChat} disabled={disabled}>
-      <IconWrapper>
+      <EndChatIcon>
         <Icon icon="CloseLarge" />
-      </IconWrapper>
-      <EndChatWrapper>
+      </EndChatIcon>
+      <EndChatText>
         <Template code="EndChatButtonLabel" />
-      </EndChatWrapper>
+      </EndChatText>
     </StyledEndButton>
   );
 }

--- a/src/end-chat/end-chat-styles.tsx
+++ b/src/end-chat/end-chat-styles.tsx
@@ -18,37 +18,63 @@ import * as FlexWebChat from '@twilio/flex-webchat-ui';
 
 const { styled } = FlexWebChat;
 
-export const EndChatWrapper = styled('span')`
-  width: 100%;
-`;
-
-export const IconWrapper = styled('div')`
-  position: relative;
-  left: 5%;
-`;
-
-export const StyledEndButton = styled('button')`
-  width: 90%;
-  display: flex;
-  background-color: #fff;
-  color: #d22f2f;
-  height: 29px;
-  font-weight: bold;
-  border: 1.5px solid #d22f2f;
-  border-radius: 4px;
-  cursor: pointer;
-  font-family: Open Sans;
-  font-size: 12px;
-  margin-left: 5px;
-  height: 29px;
-  line-height: 24px;
-`;
-
-export const ButtonWrapper = styled('div')`
+export const ButtonsWrapper = styled('div')`
   display: flex;
   text-align: center;
   margin: -20px auto auto auto;
   padding-top: 25px;
+  width: 100%;
+`;
+
+export const EndChatText = styled('span')`
+  flex-grow: 1;
+  text-align: center;
+`;
+
+export const EndChatIcon = styled('span')`
+  position: relative;
+  left: 20%;
+`;
+
+export const StyledEndButton = styled('button')`
+  align-items: center;
+  background-color: #fff;
+  border: 1.5px solid #d22f2f;
+  border-radius: 4px;
+  color: #d22f2f;
+  cursor: pointer;
+  display: flex;
+  font-family: Open Sans;
+  font-size: 12px;
+  font-weight: bold;
+  height: 29px;
+  margin-left: 5px;
+  width: 90%;
+`;
+
+export const QuickExitText = styled('span')`
+  position: relative;
+  top: -20%;
+  left: -7%;
+`;
+
+export const StyledQuickExitButton = styled('button')`
+  width: 90%;
+  /* display: inline-block; */
+  background-color: #d22f2f;
+  color: #fff;
+  font-weight: bold;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: Open Sans;
+  font-size: 12px;
+  margin-right: -10px;
+  height: 29px;
+  align-items: center;
+`;
+
+export const ExitWrapper = styled('div')`
   width: 100%;
 `;
 
@@ -63,31 +89,4 @@ export const ExitDescText = styled('p')`
     display: inline-block;
     width: 100%;
   }
-`;
-
-export const StyledQuickExitButton = styled('button')`
-  width: 90%;
-  display: inline-block;
-  background-color: #d22f2f;
-  color: #fff;
-  font-weight: bold;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-family: Open Sans;
-  font-size: 12px;
-  margin-right: -10px;
-  height: 29px;
-  line-height: 24px;
-`;
-
-export const QuickExitText = styled('span')`
-  position: relative;
-  top: -20%;
-  left: -7%;
-`;
-
-// eslint-disable-next-line import/no-unused-modules
-export const ExitWrapper = styled('div')`
-  width: 100%;
 `;

--- a/src/end-chat/end-chat-styles.tsx
+++ b/src/end-chat/end-chat-styles.tsx
@@ -60,7 +60,6 @@ export const QuickExitText = styled('span')`
 
 export const StyledQuickExitButton = styled('button')`
   width: 90%;
-  /* display: inline-block; */
   background-color: #d22f2f;
   color: #fff;
   font-weight: bold;

--- a/src/end-chat/end-chat-styles.tsx
+++ b/src/end-chat/end-chat-styles.tsx
@@ -26,16 +26,6 @@ export const ButtonsWrapper = styled('div')`
   width: 100%;
 `;
 
-export const EndChatText = styled('span')`
-  flex-grow: 1;
-  text-align: center;
-`;
-
-export const EndChatIcon = styled('span')`
-  position: relative;
-  left: 20%;
-`;
-
 export const StyledEndButton = styled('button')`
   align-items: center;
   background-color: #fff;
@@ -50,6 +40,20 @@ export const StyledEndButton = styled('button')`
   height: 29px;
   margin-left: 5px;
   width: 90%;
+`;
+
+export const EndChatText = styled('span')`
+  flex-grow: 1;
+  text-align: center;
+`;
+
+export const EndChatIcon = styled('span')`
+  position: relative;
+  left: 7%;
+`;
+
+export const ExitWrapper = styled('div')`
+  width: 100%;
 `;
 
 export const QuickExitText = styled('span')`
@@ -71,10 +75,6 @@ export const StyledQuickExitButton = styled('button')`
   margin-right: -10px;
   height: 29px;
   align-items: center;
-`;
-
-export const ExitWrapper = styled('div')`
-  width: 100%;
 `;
 
 export const ExitDescText = styled('p')`


### PR DESCRIPTION
## Description


### Checklist
- [n/a] Corresponding issue has been opened
- [n/a] New tests added

### Related Issues
 see slack discussion - https://tech-matters.slack.com/archives/CV4QM23UJ/p1681247495162329

### Verification steps
- Difficult to confirm because only certain phones have this issue in mobile view. One way is to increase height of StyledButtons for End and Exit, and check `Quick Exit` position