### PR TITLE
Fix to preEngagementConfigs with zero fields

### DIFF
--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -35,7 +35,7 @@ import type { Configuration } from '../types';
 // eslint-disable-next-line import/no-unresolved
 import { config } from './config';
 import { renderEmojis } from './emoji-picker/renderEmojis';
-import PreEngagementForm from './pre-engagement-form';
+import PreEngagementForm, { PLACEHOLDER_PRE_ENGAGEMENT_CONFIG } from './pre-engagement-form';
 import { setFormDefinition } from './pre-engagement-form/state';
 import { applyWidgetBranding } from './branding-overrides';
 
@@ -117,7 +117,7 @@ export const initWebchat = async () => {
     accountSid: currentConfig.accountSid,
     flexFlowSid: currentConfig.flexFlowSid,
     startEngagementOnInit: false,
-    preEngagementConfig: currentConfig.preEngagementConfig,
+    preEngagementConfig: PLACEHOLDER_PRE_ENGAGEMENT_CONFIG,
     context: {
       ip,
     },

--- a/src/pre-engagement-form/index.tsx
+++ b/src/pre-engagement-form/index.tsx
@@ -27,8 +27,9 @@ import { LocalizationProvider } from './localization';
 import SubmitButton from './form-components/submit-button';
 import Title from './form-components/title';
 import { resetForm } from './state';
+import { PLACEHOLDER_PRE_ENGAGEMENT_CONFIG } from './placeholder-form';
 
-export { PreEngagementFormDefinition };
+export { PreEngagementFormDefinition, PLACEHOLDER_PRE_ENGAGEMENT_CONFIG };
 
 export const EMAIL_PATTERN = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i;
 

--- a/src/pre-engagement-form/placeholder-form.tsx
+++ b/src/pre-engagement-form/placeholder-form.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+/**
+ * WebChat is created by using the function FlexWebChat.createWebChat(config).
+ * The 'config' parameter expects the property 'preEngagementConfig' to have at
+ * least one field defined.
+ *
+ * This file will provide a placeholder preEngagementConfig that will be used to
+ * call FlexWebChat.createWebChat(config) initially. But that's just to bypass this
+ * WebChat limitation, because we're actually replacing the Twilio's default PreEngagement
+ * with a custom one.
+ */
+
+export const PLACEHOLDER_PRE_ENGAGEMENT_CONFIG = {
+  fields: [
+    {
+      label: 'Hidden Field',
+      type: 'InputField',
+      attributes: {
+        name: '',
+        readOnly: true,
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Description
Fixes `co-staging` webchat.
This PR overcomes Twilio's WebChat limitation that we need to pass  `config.preEngagementConfig` in a certain format.

Before:
![webchat-issue](https://user-images.githubusercontent.com/1504544/231557246-0d474686-ecab-4d61-bdcb-5b2bbda8eceb.png)

After:
![image](https://user-images.githubusercontent.com/1504544/231557309-2acbf72e-c59d-4192-b999-9208c6192525.png)

### Related Issues
Fixes https://tech-matters.atlassian.net/browse/CHI-1869

### Verification steps
Check that `co-staging` works.
