### PR TITLE
add attribute to configure background and text/font/color

### DIFF
--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -32,6 +32,7 @@ import { aseloReducer } from './aselo-webchat-state';
 import { subscribeToChannel } from './task';
 import { addContactIdentifierToContext } from './contact-identifier';
 import type { Configuration } from '../types';
+// eslint-disable-next-line import/no-unresolved
 import { config } from './config';
 import { renderEmojis } from './emoji-picker/renderEmojis';
 import PreEngagementForm from './pre-engagement-form';

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -23,7 +23,7 @@ import { Reducer } from 'redux';
 
 import { getUserIp } from './ip-tracker';
 import { displayOperatingHours } from './operating-hours';
-import { updateZIndex, getWebChatLanguageAttributeValue } from './dom-utils';
+import { updateZIndex, getWebChatAttributeValues } from './dom-utils';
 import blockedIps from './blockedIps.json';
 import CloseChatButtons from './end-chat/CloseChatButtons';
 import { getChangeLanguageWebChat } from './language';
@@ -32,7 +32,6 @@ import { aseloReducer } from './aselo-webchat-state';
 import { subscribeToChannel } from './task';
 import { addContactIdentifierToContext } from './contact-identifier';
 import type { Configuration } from '../types';
-// eslint-disable-next-line import/no-unresolved
 import { config } from './config';
 import { renderEmojis } from './emoji-picker/renderEmojis';
 import PreEngagementForm from './pre-engagement-form';
@@ -51,7 +50,7 @@ export const getCurrentConfig = (): Configuration => {
 };
 
 const currentConfig = getCurrentConfig();
-const externalWebChatLanguage = getWebChatLanguageAttributeValue();
+const { externalWebChatLanguage, color, backgroundColor } = getWebChatAttributeValues();
 
 const { defaultLanguage, translations } = currentConfig;
 const initialLanguage = defaultLanguage;
@@ -216,5 +215,5 @@ export const initWebchat = async () => {
   webchat.init();
 
   applyMobileOptimization(manager);
-  applyWidgetBranding();
+  applyWidgetBranding(backgroundColor as string, color as string);
 };

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -216,5 +216,7 @@ export const initWebchat = async () => {
   webchat.init();
 
   applyMobileOptimization(manager);
+
+  // This adds the custom colors to webchat and revert to the default colors if backgroundColor or color is null/undefined
   applyWidgetBranding(backgroundColor as string, color as string);
 };

--- a/src/branding-overrides/index.ts
+++ b/src/branding-overrides/index.ts
@@ -15,10 +15,22 @@
  */
 import { injectGlobal } from 'react-emotion';
 
-export const applyWidgetBranding = () => {
+export const applyWidgetBranding = (backgroundColor: string, color: string) => {
   return injectGlobal`
     .Twilio .Twilio-MainContainer {
         width: 350px;
       }
+    .Twilio .Twilio-EntryPoint {
+      background-image: linear-gradient(to top, ${backgroundColor}, ${backgroundColor});
+      color: ${color};
+     }
+    .Twilio-DynamicForm button {
+      background-image: linear-gradient(to top, ${backgroundColor}, ${backgroundColor}) !important;
+      color: ${color} !important;
+    }
+   .Twilio-MessageInput-SendButton {
+    background: ${backgroundColor} !important;
+    color: ${color} !important;
+    }
   `;
 };

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -54,6 +54,10 @@ function isHTMLElement(node: Node): node is HTMLElement {
   return node.nodeType === Node.ELEMENT_NODE;
 }
 
-export function getWebChatLanguageAttributeValue() {
-  return document?.currentScript?.getAttribute('data-language');
+export function getWebChatAttributeValues() {
+  const externalWebChatLanguage = document?.currentScript?.getAttribute('data-language');
+  const color = document?.currentScript?.getAttribute('data-color');
+  const backgroundColor = document?.currentScript?.getAttribute('data-background-color');
+
+  return { externalWebChatLanguage, color, backgroundColor };
 }


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
- New feature: Ability to configure color and fonts

### Checklist
- [x] Corresponding issue has been opened
- [N/A] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes CHI-1611

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
Description
I implemented two data attributes - data-background-color and data-color. The ticket only specifies the data-color  attribute, which mainly handles background color. But I also considered a scenario where a helpline would want to modify the text color. Any valid color value would work. E.g, Green, #66FFFF, rgb(102, 255, 255), hsl(180, 100%, 70%).

https://app.box.com/notes/850639952620
