### PR TITLE
CustomMessageBubble added to ensure automated messages shows theirDefaultName accurately

### DIFF
--- a/configurations/as-development.ts
+++ b/configurations/as-development.ts
@@ -204,6 +204,12 @@ const blockedEmojis = [
   'syringe',
   'pill',
 ];
+const memberDisplayOptions = {
+  yourDefaultName: 'You',
+  yourFriendlyNameOverride: false,
+  theirFriendlyNameOverride: false,
+  theirDefaultName: 'Counsellor',
+};
 
 export const config: Configuration = {
   accountSid,
@@ -219,4 +225,5 @@ export const config: Configuration = {
   contactType,
   showEmojiPicker,
   blockedEmojis,
+  memberDisplayOptions
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4525,6 +4525,11 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
     },
+    "date-fns": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
+    },
     "debounce": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@twilio/flex-webchat-ui": "^2.9.1",
     "buffer": "^6.0.3",
+    "date-fns": "^2.29.3",
     "dompurify": "^3.0.1",
     "pubsub-js": "^1.9.4",
     "react-hook-form": "^7.43.7",

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -35,6 +35,7 @@ import type { Configuration } from '../types';
 // eslint-disable-next-line import/no-unresolved
 import { config } from './config';
 import { renderEmojis } from './emoji-picker/renderEmojis';
+import { renderCustomMessageBubble } from './messagebubble-component/renderCustomMessageBubble';
 import PreEngagementForm, { PLACEHOLDER_PRE_ENGAGEMENT_CONFIG } from './pre-engagement-form';
 import { setFormDefinition } from './pre-engagement-form/state';
 import { applyWidgetBranding } from './branding-overrides';
@@ -166,6 +167,8 @@ export const initWebchat = async () => {
         yourFriendlyNameOverride: false,
         theirFriendlyNameOverride: true,
       };
+
+  renderCustomMessageBubble();
 
   // Hide message input and send button if disabledReason is not undefined
   FlexWebChat.MessageInput.Content.remove('textarea', {

--- a/src/messagebubble-component/CustomMessageBubble.tsx
+++ b/src/messagebubble-component/CustomMessageBubble.tsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+// import { MessageBubble } from '@twilio/flex-webchat-ui';
+import React from 'react';
+import { format } from 'date-fns';
+
+import {
+  CustomBubbleContainer,
+  CustomBubbleHeader,
+  CustomBubbleUserName,
+  CustomBubbleTime,
+  CustomBubbleBody,
+} from './message-bubble-styles';
+
+export default function Bubble(props: any) {
+  const { member, message, authorName } = props;
+
+  return (
+    <CustomBubbleContainer>
+      <CustomBubbleHeader style={{ color: message.isFromMe ? '#fff' : '#000' }}>
+        <CustomBubbleUserName>{message.source.memberSid ? authorName : member.friendlyName}</CustomBubbleUserName>
+        <CustomBubbleTime>{format(new Date(message.source.timestamp), 'h:mm a')}</CustomBubbleTime>
+      </CustomBubbleHeader>
+      <CustomBubbleBody>{message.source.body}</CustomBubbleBody>
+    </CustomBubbleContainer>
+  );
+}

--- a/src/messagebubble-component/message-bubble-styles.tsx
+++ b/src/messagebubble-component/message-bubble-styles.tsx
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import * as FlexWebChat from '@twilio/flex-webchat-ui';
+
+const { styled } = FlexWebChat;
+
+export const CustomBubbleContainer = styled('div')`
+  display: flex;
+  flex-wrap: nowrap;
+  flex-grow: 1;
+  flex-direction: column;
+  overflow-x: hidden;
+`;
+
+export const CustomBubbleHeader = styled('div')`
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 5px;
+  justify-content: space-between;
+  color: #222222;
+  display: flex;
+  flex-wrap: nowrap;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-direction: row;
+`;
+
+export const CustomBubbleUserName = styled('div')`
+  font-size: 10px;
+  margin-top: 0;
+  margin-bottom: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  -webkit-flex: 0 1 auto;
+  -ms-flex: 0 1 auto;
+  flex: 0 1 auto;
+  margin-right: 8px;
+  font-weight: bold;
+`;
+
+export const CustomBubbleTime = styled('div')`
+  font-size: 10px;
+  margin-top: 0;
+  margin-bottom: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+`;
+
+export const CustomBubbleBody = styled('div')`
+  padding-left: 12px;
+  padding-right: 12px;
+  margin-top: 3px;
+  margin-bottom: 0px;
+  font-size: 12px;
+  line-height: 1.54;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  padding-bottom: 8px;
+`;

--- a/src/messagebubble-component/renderCustomMessageBubble.tsx
+++ b/src/messagebubble-component/renderCustomMessageBubble.tsx
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import React from 'react';
+import * as FlexWebChat from '@twilio/flex-webchat-ui';
+
+import CustomMessageBubble from './CustomMessageBubble';
+
+export const renderCustomMessageBubble = () => {
+  FlexWebChat.MessageListItem.Bubble.Content.replace(<CustomMessageBubble key="header" />);
+};


### PR DESCRIPTION
## Description
- Replaced MessageBubble to ensure Bot and System `from` field shows the correct author name when `memberDisplayOptions` are set in helpline configurations.  
- Added CustomMessageBubble and styling identical to twilio native MessageBubble component

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes # [1627](https://tech-matters.atlassian.net/browse/CHI-1647)

### Verification steps
- This PR has as-development with `memberDisplayOptions` set. Check that the styling is identical and author of bot vs. counsellor text is accurate