### PR TITLE
Make language selected at pre-engagement override language on context

### DIFF
--- a/src/language.ts
+++ b/src/language.ts
@@ -36,6 +36,20 @@ const standardTranslationsForLanguage = (language: string): Record<string, strin
   return { ...languageTranslations, ...cultureSpecificTranslations };
 };
 
+export const overrideLanguageOnContext = (manager: FlexWebChat.Manager, language: string) => {
+  const appConfig = manager.configuration;
+
+  const updateConfig = {
+    ...appConfig,
+    context: {
+      ...appConfig.context,
+      language,
+    },
+  };
+
+  manager.updateConfig(updateConfig);
+};
+
 export const getChangeLanguageWebChat = (manager: FlexWebChat.Manager, config: Configuration) => {
   const { defaultLanguage, translations: configTranslations } = config;
   const setNewLanguage = (language: string) => {
@@ -65,18 +79,7 @@ export const getChangeLanguageWebChat = (manager: FlexWebChat.Manager, config: C
   return (language: string) => {
     try {
       setNewLanguage(language);
-
-      const appConfig = manager.configuration;
-
-      const updateConfig = {
-        ...appConfig,
-        context: {
-          ...appConfig.context,
-          language,
-        },
-      };
-
-      manager.updateConfig(updateConfig);
+      overrideLanguageOnContext(manager, language);
     } catch (err) {
       const translationErrorMsg = 'Could not translate, using default';
       window.alert(translationErrorMsg);

--- a/src/pre-engagement-form/index.tsx
+++ b/src/pre-engagement-form/index.tsx
@@ -28,6 +28,7 @@ import SubmitButton from './form-components/submit-button';
 import Title from './form-components/title';
 import { resetForm } from './state';
 import { PLACEHOLDER_PRE_ENGAGEMENT_CONFIG } from './placeholder-form';
+import { overrideLanguageOnContext } from '../language';
 
 export { PreEngagementFormDefinition, PLACEHOLDER_PRE_ENGAGEMENT_CONFIG };
 
@@ -45,6 +46,15 @@ const PreEngagementForm: React.FC<Props> = ({ formState: defaultValues, formDefi
 
   const onSubmit = handleSubmit(async (data) => {
     const payload = { formData: data };
+
+    /**
+     * If 'language' is defined at the pre-engagement form
+     * it should override the language value on Context.
+     */
+    if (data.language) {
+      overrideLanguageOnContext(manager, data.language);
+    }
+
     await FlexWebChat.Actions.invokeAction('StartEngagement', payload);
     resetFormAction();
   });


### PR DESCRIPTION
## Description
By default, context variables override pre-engagement variables with the same name.
For `language`, specifically, we want the other way, the one selected at pre-engagement should take precedence.

This PR, at submit time, makes the `language` value from pre-engagement overrides the value on context.

### Related Issues
Fixes [CHI-1911](https://tech-matters.atlassian.net/browse/CHI-1911)

### Verification steps
Create a pre-engagement form with language.
Select a language that's different than the one in the context.
Start a conversation and check that the `language` passed is the on from the pre-engagement.
