### PR TITLE
CHI-1888 region specific recaptcha verify url for CA prod

### DIFF
--- a/.github/workflows/canada_production.yml
+++ b/.github/workflows/canada_production.yml
@@ -28,3 +28,5 @@ jobs:
     with:
       environment: production
       helpline_code: CA
+      # this is part of a dirty hack to get the right recaptcha_verify_url. see note on the "Fill secret.ts" step of custom_helpline.yml
+      recaptcha_verify_url: https://hrm-production-ca.tl.techmatters.org/lambdas/recaptchaVerify

--- a/.github/workflows/custom_helpline.yml
+++ b/.github/workflows/custom_helpline.yml
@@ -30,6 +30,13 @@ on:
         description: "Helpline Environment"
         required: true
         type: string
+      recaptcha_verify_url:
+        description: "Recaptcha Verify URL"
+        required: false
+        type: string
+
+env:
+  recaptcha_verify_url: https://hrm-${inputs.environment}.tl.techmatters.org/lambda/recaptchaVerify
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -118,13 +125,16 @@ jobs:
         run: |
           touch ./private/secret.ts
 
+      # This includes a dirty hack to get the recaptcha_verify_url into the secret.ts file with the correct region for CA
+      # We should really start adding a helpline specific HRM url to the SSM parameters as part of twilio_iac and pulling
+      # that in here, but this will do for now.
       - name: Fill secret.ts
         run: |
           cat <<EOT >> ./private/secret.ts
           export const API_KEY = '${{ env.IP_FIND_API_KEY }}';
           export const SERVERLESS_URL = '${{ env.SERVERLESS_URL }}';
           export const RECAPTCHA_KEY = '${{ env.RECAPTCHA_KEY }}';
-          export const RECAPTCHA_VERIFY_URL = 'https://hrm-${inputs.environment}.tl.techmatters.org/lambda/recaptchaVerify'
+          export const RECAPTCHA_VERIFY_URL = '${{ inputs.recaptcha_verify_url || env.recaptcha_verify_url }}';
           EOT
 
       # Run a single command using the runners shell to install dependencies

--- a/.github/workflows/custom_helpline.yml
+++ b/.github/workflows/custom_helpline.yml
@@ -36,7 +36,7 @@ on:
         type: string
 
 env:
-  recaptcha_verify_url: https://hrm-${inputs.environment}.tl.techmatters.org/lambda/recaptchaVerify
+  recaptcha_verify_url: https://hrm-${{ inputs.environment }}.tl.techmatters.org/lambda/recaptchaVerify
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
## Description

This adds a very hacky way to override the verify url for CA production. So that we only keep logs that contain caller IP information in CA per the PII requirements. 

The Right Way™ would involve adding a new SSM param to every helpline in TWILIO iac that contains the correct `hrm_url` and then looking it up at deploy time or adding a region definition to each helpline workflow that could be used to map to the correct url, but either of those solutions would require a lot more work than the current problem probably deserves.