### PR TITLE
Set language context language before checking open hours

### DIFF
--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -144,10 +144,9 @@ export const initWebchat = async () => {
   manager.store.dispatch(setFormDefinition(currentConfig.preEngagementConfig));
 
   const changeLanguageWebChat = getChangeLanguageWebChat(manager, currentConfig);
-
-  await displayOperatingHours(currentConfig, manager);
-
   changeLanguageWebChat(externalWebChatLanguage || initialLanguage);
+
+  await displayOperatingHours(currentConfig, manager, externalWebChatLanguage);
 
   // If caller is waiting for a counselor to connect, disable input (default language)
   if (manager.chatClient) {

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -143,9 +143,9 @@ export const initWebchat = async () => {
   manager.store.replaceReducer(aseloReducer as Reducer<FlexState>);
   manager.store.dispatch(setFormDefinition(currentConfig.preEngagementConfig));
 
-  await displayOperatingHours(currentConfig, manager);
-
   const changeLanguageWebChat = getChangeLanguageWebChat(manager, currentConfig);
+
+  await displayOperatingHours(currentConfig, manager);
 
   changeLanguageWebChat(externalWebChatLanguage || initialLanguage);
 

--- a/src/operating-hours.ts
+++ b/src/operating-hours.ts
@@ -48,13 +48,16 @@ const getOperatingHours = async (language: string): Promise<OperatingHoursRespon
   return responseJson;
 };
 
-// eslint-disable-next-line sonarjs/cognitive-complexity
-export const displayOperatingHours = async (config: Configuration, manager: Manager) => {
+export const displayOperatingHours = async (
+  config: Configuration,
+  manager: Manager,
+  externalWebChatLanguage?: string,
+  // eslint-disable-next-line sonarjs/cognitive-complexity
+) => {
   // If a helpline has operating hours configuration set, the pre engagement config will show alternative canvas during closed or holiday times/days
   if (config.checkOpenHours) {
     try {
-      const operatingState = await getOperatingHours(config.defaultLanguage);
-
+      const operatingState = await getOperatingHours(externalWebChatLanguage || config.defaultLanguage);
       /*
        * Support legacy function to avoid braking changes
        * TODO: remove once every account has been migrated

--- a/src/operating-hours.ts
+++ b/src/operating-hours.ts
@@ -51,7 +51,7 @@ const getOperatingHours = async (language: string): Promise<OperatingHoursRespon
 export const displayOperatingHours = async (
   config: Configuration,
   manager: Manager,
-  externalWebChatLanguage?: string,
+  externalWebChatLanguage?: string | null,
   // eslint-disable-next-line sonarjs/cognitive-complexity
 ) => {
   // If a helpline has operating hours configuration set, the pre engagement config will show alternative canvas during closed or holiday times/days


### PR DESCRIPTION
## Description
This PR adds support for using the `externalWebChatLanguage` when checking the operating status of the helpline, in order to display a translated message if the response is either closed or holidays.

![Screenshot from 2023-05-05 16-40-00](https://user-images.githubusercontent.com/15805319/236490474-1220a298-7d83-49a1-982b-90d2b39af5af.png)

### Verification steps
- Go to serverless repo, and `assets/operatingInfo/aselo-dev.private.json` change to
  ```
  "webchat": {
      "1": [],
      "2": [],
      "3": [],
      "4": [],
      "5": [],
      "6": [],
      "7": []
    }
  ```
  to force a closed state. Make sure you have a recent version that already contains `assets/translations/fr-CA/messages.private.json` asset. 
- Locally serve a serverless instance with above change (`npm start`) and expose via `ngrok`.
- Make your local instance of webchat point to above ngrok generated url by setting `SERVERLESS_URL` in `private/secret.ts`.
- `npm start`.
- Start a new webchat and confirm the message indicating that the helpline is closed is in English.
- Change `getWebChatAttributeValues` function in `src/dom-utils.ts` to return `const externalWebChatLanguage = 'fr-CA`.
- Reload webchat (shift+f5) and confirm that if the external language is set, the message indicating that the helpline is closed will be translated (if the translation exists).
- Repeat the last two steps with a non-existing language like `const externalWebChatLanguage = 'xxxxxx` and confirm that the message defaults to English.