### PR TITLE
CHI-2158: disable office hours for e2e, dev hot reload

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,14 +1,12 @@
 {
-  "extends": [
-    "twilio-react"
-  ],
+  "extends": ["twilio-react", "prettier/prettier"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2019,
-    "sourceType": "module", 
-    "ecmaFeatures": { 
-    "jsx": true
-   }
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true
+    }
   },
   "rules": {
     "no-console": "off",

--- a/.github/workflows/custom_helpline.yml
+++ b/.github/workflows/custom_helpline.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Upload e2e-chat html file to assets S3 bucket
         uses: jakejarvis/s3-sync-action@master
         with:
-          args: --acl public-read --follow-symlinks --exclude '*' --include 'e2e-chat.html' --content-type 'text/html; charset=utf-8'
+          args: --acl public-read --follow-symlinks --exclude '*' --include 'e2e-chat.html' --include 'test-chat.html' --content-type 'text/html; charset=utf-8'
         env:
           AWS_S3_BUCKET: assets-${{ inputs.environment }}.tl.techmatters.org
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (C) 2021-2023 Technology Matters
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+const baseConfig = require('./node_modules/eslint-config-twilio/rules/prettier');
+
+module.exports = {
+  ...baseConfig,
+};

--- a/assets/test-chat.html
+++ b/assets/test-chat.html
@@ -16,20 +16,9 @@
 
 <html>
   <head>
-    <title>My chat</title>
+    <title>Test Webchat</title>
   </head>
   <body>
-    <div
-      style="
-        position: fixed;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        height: 123px;
-        background-color: #261e3c;
-        z-index: 999999;
-      "
-    ></div>
-    <script data-z-index="16000160" src="./bundle.js"></script>
+    <script src="./aselo-chat.min.js"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@babel/preset-react": "^7.18.6",
         "@babel/preset-typescript": "^7.18.6",
         "@emoji-mart/react": "^1.1.1",
+        "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
         "@types/dompurify": "^3.0.1",
         "@types/jest": "^29.2.6",
         "@types/pubsub-js": "^1.8.3",
@@ -3216,6 +3217,160 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.10.tgz",
+      "integrity": "sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-html-community": "^0.0.8",
+        "common-path-prefix": "^3.0.0",
+        "core-js-pure": "^3.23.3",
+        "error-stack-parser": "^2.0.6",
+        "find-up": "^5.0.0",
+        "html-entities": "^2.1.0",
+        "loader-utils": "^2.0.4",
+        "schema-utils": "^3.0.0",
+        "source-map": "^0.7.3"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "@types/webpack": "4.x || 5.x",
+        "react-refresh": ">=0.10.0 <1.0.0",
+        "sockjs-client": "^1.4.0",
+        "type-fest": ">=0.17.0 <4.0.0",
+        "webpack": ">=4.43.0 <6.0.0",
+        "webpack-dev-server": "3.x || 4.x",
+        "webpack-hot-middleware": "2.x",
+        "webpack-plugin-serve": "0.x || 1.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/webpack": {
+          "optional": true
+        },
+        "sockjs-client": {
+          "optional": true
+        },
+        "type-fest": {
+          "optional": true
+        },
+        "webpack-dev-server": {
+          "optional": true
+        },
+        "webpack-hot-middleware": {
+          "optional": true
+        },
+        "webpack-plugin-serve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/html-entities": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.4.0.tgz",
+      "integrity": "sha512-igBTJcNNNhvZFRtm8uA6xMY6xYleeDwn3PeBCkDz7tHttv4F2hsDI2aPgNERWzvRcNYHNT3ymRaQzllmXj4YsQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ]
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/schema-utils": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.51",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
@@ -5781,6 +5936,12 @@
         "node": ">= 12"
       }
     },
+    "node_modules/common-path-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
+      "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
+      "dev": true
+    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -6733,6 +6894,15 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "dev": true,
+      "dependencies": {
+        "stackframe": "^1.3.4"
       }
     },
     "node_modules/es-abstract": {
@@ -13628,6 +13798,16 @@
         "redux": "^2.0.0 || ^3.0.0 || ^4.0.0-0"
       }
     },
+    "node_modules/react-refresh": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
+      "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
@@ -14843,6 +15023,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+      "dev": true
     },
     "node_modules/static-extend": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "start": "cross-env MODE=development CONFIG=as-development webpack serve --open",
+    "start": "cross-env MODE=development CONFIG=as-development webpack serve",
     "build": "cross-env webpack",
     "build:dev": "cross-env MODE=development CONFIG=as-development webpack",
     "lint": "eslint --ext js --ext jsx --ext ts --ext tsx src/",
@@ -22,6 +22,7 @@
     "@babel/preset-react": "^7.18.6",
     "@babel/preset-typescript": "^7.18.6",
     "@emoji-mart/react": "^1.1.1",
+    "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
     "@types/dompurify": "^3.0.1",
     "@types/jest": "^29.2.6",
     "@types/pubsub-js": "^1.8.3",

--- a/src/aselo-webchat.tsx
+++ b/src/aselo-webchat.tsx
@@ -42,17 +42,29 @@ import { applyWidgetBranding } from './branding-overrides';
 
 updateZIndex();
 
+const e2eTestModeConfigOverride = {
+  enableRecaptcha: false,
+  checkOpenHours: false,
+};
+
+const { externalWebChatLanguage, color, backgroundColor, e2eTestMode } = getWebChatAttributeValues();
 // eslint-disable-next-line import/no-unused-modules
 export const getCurrentConfig = (): Configuration => {
   if (!config) {
     throw new Error(`Failed trying to load config file ${webpack.env.CONFIG}`);
   }
 
+  if (e2eTestMode) {
+    return {
+      ...config,
+      ...e2eTestModeConfigOverride,
+    };
+  }
+
   return config;
 };
 
 const currentConfig = getCurrentConfig();
-const { externalWebChatLanguage, color, backgroundColor, e2eTestMode } = getWebChatAttributeValues();
 
 const { defaultLanguage, translations } = currentConfig;
 const initialLanguage = defaultLanguage;
@@ -214,12 +226,7 @@ export const initWebchat = async () => {
 
   // Replace pre engagement form
   FlexWebChat.PreEngagementCanvas.Content.replace(
-    <PreEngagementForm
-      key="pre-engagement"
-      manager={manager}
-      enableRecaptcha={currentConfig.enableRecaptcha}
-      bypassCaptcha={e2eTestMode}
-    />,
+    <PreEngagementForm key="pre-engagement" manager={manager} enableRecaptcha={currentConfig.enableRecaptcha} />,
   );
 
   // Render WebChat

--- a/src/end-chat/EndChat.tsx
+++ b/src/end-chat/EndChat.tsx
@@ -47,7 +47,9 @@ export default function EndChat({ channelSid, token, language, action }: Props) 
         return;
       case 'restartEngagement':
       default:
-        await FlexWebChat.Actions.invokeAction('RestartEngagement', { exit: false });
+        await FlexWebChat.Actions.invokeAction('RestartEngagement', {
+          exit: false,
+        });
     }
   };
   return (

--- a/src/operating-hours.ts
+++ b/src/operating-hours.ts
@@ -20,7 +20,11 @@ import { Configuration, OperatingHoursResponse } from '../types';
 import { setFormDefinition } from './pre-engagement-form/state';
 
 const getOperatingHours = async (language: string): Promise<OperatingHoursResponse> => {
-  const body = { channel: 'webchat', includeMessageTextInResponse: 'true', language };
+  const body = {
+    channel: 'webchat',
+    includeMessageTextInResponse: 'true',
+    language,
+  };
 
   const options = {
     method: 'POST',

--- a/src/pre-engagement-form/ReCaptcha/index.tsx
+++ b/src/pre-engagement-form/ReCaptcha/index.tsx
@@ -21,29 +21,24 @@ import { RECAPTCHA_KEY } from '../../../private/secret';
 import { validateUser } from './recaptchaValidation';
 
 type Props = {
-  bypassCaptcha: boolean | undefined;
   onRecaptchaChange: (verified: boolean) => void;
 };
 
-const ReCaptcha: React.FC<Props> = ({ bypassCaptcha, onRecaptchaChange }) => {
+const ReCaptcha: React.FC<Props> = ({ onRecaptchaChange }) => {
   const recaptchaRef = useRef<ReCAPTCHA>(null);
 
-  const onChange = (token: string | null) => {
+  const onChange = async (token: string | null) => {
     const verified = token !== null;
     onRecaptchaChange(verified);
 
     if (verified) {
       try {
-        validateUser(token ?? '');
+        await validateUser(token ?? '');
       } catch (error) {
         console.log(error);
       }
     }
   };
-
-  if (bypassCaptcha) {
-    return null;
-  }
 
   return <ReCAPTCHA sitekey={RECAPTCHA_KEY} size="normal" ref={recaptchaRef} onChange={onChange} />;
 };

--- a/src/pre-engagement-form/index.tsx
+++ b/src/pre-engagement-form/index.tsx
@@ -15,7 +15,7 @@
  */
 
 /* eslint-disable react/require-default-props */
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import { useForm, FormProvider } from 'react-hook-form';
 import * as FlexWebChat from '@twilio/flex-webchat-ui';
@@ -38,7 +38,6 @@ export const EMAIL_PATTERN = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i;
 type Props = {
   manager: FlexWebChat.Manager;
   enableRecaptcha?: boolean;
-  bypassCaptcha?: boolean;
 } & ReturnType<typeof mapStateToProps> &
   typeof mapDispatchToProps;
 
@@ -49,7 +48,6 @@ const PreEngagementForm: React.FC<Props> = ({
   resetFormAction,
   enableRecaptcha,
   friendlyName,
-  bypassCaptcha,
 }) => {
   const methods = useForm({ defaultValues, mode: 'onChange' });
   const { handleSubmit, formState } = methods;
@@ -106,12 +104,11 @@ const PreEngagementForm: React.FC<Props> = ({
         <form className="Twilio-DynamicForm" onSubmit={onSubmit}>
           <Title title={formDefinition.description} />
           {generateForm(formDefinition.fields)}
-          {enableRecaptcha && <ReCaptcha bypassCaptcha={bypassCaptcha} onRecaptchaChange={setIsRecaptchaVerified} />}
+          {enableRecaptcha && <ReCaptcha onRecaptchaChange={setIsRecaptchaVerified} />}
           {formDefinition.submitLabel && (
             <SubmitButton
               label={formDefinition.submitLabel}
-              // disabled prop set to true if the form is invalid or the Recaptcha is not verified or bypassCaptcha
-              disabled={!isValid || ((enableRecaptcha ?? false) && !isRecaptchaVerified && !bypassCaptcha)}
+              disabled={!isValid || ((enableRecaptcha ?? false) && !isRecaptchaVerified)}
             />
           )}
         </form>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,7 @@ const webpack = require('webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const BomPlugin = require('webpack-utf8-bom');
+const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 
 const { checkMODE, setConfigFile } = require('./utils');
 
@@ -28,15 +29,19 @@ const config = process.env.CONFIG;
 checkMODE(mode);
 setConfigFile(config);
 
-const devtool = mode === 'development' ? 'eval-source-map' : undefined;
+const isDevMode = mode === 'development';
+const devtool = isDevMode ? 'eval-source-map' : undefined;
 
-module.exports = {
+const webpackConfig = {
   mode,
   devtool,
   devServer: {
-    contentBase: './build',
-    compress: true,
+    contentBase: path.join(__dirname, './'),
+    compress: true, s
     port: 9000,
+    open: true,
+    inline: true,
+    hot: true,
   },
   entry: './src/index.ts',
   module: {
@@ -75,18 +80,19 @@ module.exports = {
     extensions: ['.ts', '.js', '.tsx'],
     fallback: {
       buffer: require.resolve('buffer'),
+      fs: false,
     },
   },
   output: {
     filename: 'bundle.js',
     path: path.resolve(__dirname, 'build'),
+    publicPath: '/',
   },
   plugins: [
     new HtmlWebpackPlugin({
       template: 'src/index.html',
-      inject: false, // This prevents webpack from injecting <script defer src="./bundle.js"></script> in the header
+      inject: false, // This prevents webpack from injecting <script defer src='./bundle.js'></script> in the header
     }),
-    new BomPlugin(true),
     new webpack.ProvidePlugin({
       process: 'process/browser',
     }),
@@ -97,9 +103,20 @@ module.exports = {
     new CopyWebpackPlugin({
       patterns: [{ from: 'assets' }],
     }),
+    new webpack.HotModuleReplacementPlugin(),
+    new ReactRefreshWebpackPlugin({
+      overlay: false,
+    }),
   ],
   externals: {
     // eslint-disable-next-line global-require
     fs: require('fs'),
   },
 };
+
+if (!isDevMode) {
+  // The bom plugin breaks the dev server and hot
+  webpackConfig.plugins.push(new BomPlugin(true));
+}
+
+module.exports = webpackConfig;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,7 +37,7 @@ const webpackConfig = {
   devtool,
   devServer: {
     contentBase: path.join(__dirname, './'),
-    compress: true, s
+    compress: true,
     port: 9000,
     open: true,
     inline: true,


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
While fixing the e2eTestMode to disable office hours and refactoring it to override the configuration instead of passing new flags around, I added a test-chat.html to be deployed to all helplines assets folder so we can test any helpline. I also fixed/enabled hot reload for the webpack dev server.

### Checklist
- [ ] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes #....

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->
Run dev server locally, deploy to development and test chat there.
