### PR TITLE
L3 bug investigation: webchat widget title "Chat With Us" is not translated

### DIFF
--- a/src/language.ts
+++ b/src/language.ts
@@ -38,7 +38,6 @@ const standardTranslationsForLanguage = (language: string): Record<string, strin
 
 export const overrideLanguageOnContext = (manager: FlexWebChat.Manager, language: string) => {
   const appConfig = manager.configuration;
-  const [languageOnlyCode] = language.split('-');
 
   const updateConfig = {
     ...appConfig,
@@ -46,13 +45,24 @@ export const overrideLanguageOnContext = (manager: FlexWebChat.Manager, language
       ...appConfig.context,
       language,
     },
+  };
+
+  manager.updateConfig(updateConfig);
+};
+
+const setMainHeaderTitle = (manager: FlexWebChat.Manager, language: string) => {
+  const [languageOnlyCode] = language.split('-');
+
+  const appConfig = manager.configuration;
+
+  const updateConfig = {
+    ...appConfig,
     componentProps: {
       MainHeader: {
         titleText: standardTranslations[languageOnlyCode].ChatWithUs,
       },
     },
   };
-
   manager.updateConfig(updateConfig);
 };
 
@@ -76,9 +86,11 @@ export const getChangeLanguageWebChat = (manager: FlexWebChat.Manager, config: C
         ...languageTranslations,
         ...configTranslations[language],
       });
+      setMainHeaderTitle(manager, language);
     } else {
       setConfigLanguage(defaultLanguage);
       setNewStrings({ ...twilioStrings, ...defaultLanguageTranslations, ...configTranslations[defaultLanguage] });
+      setMainHeaderTitle(manager, language);
     }
   };
 

--- a/src/language.ts
+++ b/src/language.ts
@@ -38,12 +38,18 @@ const standardTranslationsForLanguage = (language: string): Record<string, strin
 
 export const overrideLanguageOnContext = (manager: FlexWebChat.Manager, language: string) => {
   const appConfig = manager.configuration;
+  const [languageOnlyCode] = language.split('-');
 
   const updateConfig = {
     ...appConfig,
     context: {
       ...appConfig.context,
       language,
+    },
+    componentProps: {
+      MainHeader: {
+        titleText: standardTranslations[languageOnlyCode].ChatWithUs,
+      },
     },
   };
 

--- a/src/language.ts
+++ b/src/language.ts
@@ -86,11 +86,11 @@ export const getChangeLanguageWebChat = (manager: FlexWebChat.Manager, config: C
         ...languageTranslations,
         ...configTranslations[language],
       });
-      setMainHeaderTitle(manager, language);
+      setMainHeaderTitle(manager, defaultLanguage);
     } else {
       setConfigLanguage(defaultLanguage);
       setNewStrings({ ...twilioStrings, ...defaultLanguageTranslations, ...configTranslations[defaultLanguage] });
-      setMainHeaderTitle(manager, language);
+      setMainHeaderTitle(manager, defaultLanguage);
     }
   };
 

--- a/src/language.ts
+++ b/src/language.ts
@@ -86,7 +86,7 @@ export const getChangeLanguageWebChat = (manager: FlexWebChat.Manager, config: C
         ...languageTranslations,
         ...configTranslations[language],
       });
-      setMainHeaderTitle(manager, defaultLanguage);
+      setMainHeaderTitle(manager, language);
     } else {
       setConfigLanguage(defaultLanguage);
       setNewStrings({ ...twilioStrings, ...defaultLanguageTranslations, ...configTranslations[defaultLanguage] });

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -19,4 +19,5 @@ export default {
   EndChatButtonLabel: 'End Chat',
   QuickExitButtonLabel: 'Quick Exit',
   QuickExitDescription: 'Need to leave immediately?',
+  ChatWithUs: 'Chat with Us',
 } as Record<string, string>;

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -19,4 +19,5 @@ export default {
   EndChatButtonLabel: 'Finalizar Chat',
   QuickExitButtonLabel: 'Salida Rápida',
   QuickExitDescription: '¿Necesitas irte rápido?',
+  ChatWithUs: 'Chatea Con Nosotros',
 } as Record<string, string>;

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -19,4 +19,5 @@ export default {
   EndChatButtonLabel: 'Terminer Chat',
   QuickExitButtonLabel: 'Sortie Rapide',
   QuickExitDescription: 'Besoin de Partir Rapidement?',
+  ChatWithUs: 'Discute avec nous',
 } as Record<string, string>;

--- a/src/translations/hu.ts
+++ b/src/translations/hu.ts
@@ -19,4 +19,5 @@ export default {
   EndChatButtonLabel: 'Csevegés befejezése',
   QuickExitButtonLabel: 'Gyors kilépés',
   QuickExitDescription: 'Gyorsan el kell menni?',
+  ChatWithUs: 'Csevegés velünk',
 } as Record<string, string>;

--- a/src/translations/ru.ts
+++ b/src/translations/ru.ts
@@ -19,4 +19,5 @@ export default {
   EndChatButtonLabel: 'Выход из чата',
   QuickExitButtonLabel: 'Быстрый выход',
   QuickExitDescription: 'Нужно быстро уйти?',
+  ChatWithUs: 'Поболтай с нами',
 } as Record<string, string>;

--- a/src/translations/ukr.ts
+++ b/src/translations/ukr.ts
@@ -19,4 +19,5 @@ export default {
   EndChatButtonLabel: 'Вийти із чату',
   QuickExitButtonLabel: 'Швидкий вихід',
   QuickExitDescription: 'Потрібно швидко піти?',
+  ChatWithUs: 'Спілкуйтеся з нами',
 } as Record<string, string>;


### PR DESCRIPTION
## Description
<!--
- What this pull request does.
- Bug fix, new feature, documentation change, etc.
-->
Bug fix: "Chat With Us" remains in English and does not translate regardless of the default-language tag. 

### Checklist
- [x] Corresponding issue has been opened
- [ ] New tests added

<!-- Uncomment for web client-related PRs
- [ ] English strings reviewed and copyedited
- [ ] Strings are localized
- [ ] Images are compressed (TinyPNG or svgo)
- [ ] Sample environment file updated (when environment variables changed)
- [ ] Verified on mobile
- [ ] Verified on desktop
- [ ] Verified accessibility ([Accessibility - Web applications](https://docs.google.com/document/d/1VwPDyLqw7r_iISMgDZr1FdAmAqqOIIVIxQqsYA-HaHE/edit?usp=sharing))
-->

### Related Issues
Fixes [CHI-1873](https://tech-matters.atlassian.net/browse/CHI-1873)

### Verification steps
<!--
Describe how to validate your changes.
- Include screen shots if applicable.
- Note if migrations are required.
-->


[CHI-1873]: https://tech-matters.atlassian.net/browse/CHI-1873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ